### PR TITLE
feat: add include/exclude support to mutationScope option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,10 @@ yarn openapi-codegen generate --config my-config.ts
   --axiosRequestConfig                Include Axios request config parameters in query hooks (default: false)
   --infiniteQueries                   Generate infinite queries for paginated API endpoints (default: false)
   --mutationEffects                   Add mutation effects options to mutation hooks (default: true)
-  --mutationScope                     Serialize mutations for the same path-param resource via TanStack scope.id (default: false)
+  --mutationScope                     Serialize mutations for the same path-param resource via TanStack scope.id (default: false).
+                                      In config files also accepts { include: string[] } or { exclude: string[] } to opt specific
+                                      operations in/out of scoping. Use "Tag/operationId" format for precision (e.g. "EmployeeSettings/update")
+                                      or just "operationId" to match across all tags. Cannot specify both include and exclude.
   --mutationDefaultOnError            Use OpenApiQueryConfig.onError as the default onError for mutation hooks (default: false)
   --workspaceContext                  Comma-separated list of path/ACL params that generated hooks may resolve from OpenApiWorkspaceContext
   --inlineEndpoints                   Inline endpoint implementations into generated query files (default: false)

--- a/src/generators/generate/generateQueries.ts
+++ b/src/generators/generate/generateQueries.ts
@@ -78,6 +78,14 @@ const endpointParamMappingCache = new WeakMap<
 
 export function generateQueries(params: GenerateTypeParams) {
   const { resolver, data, tag } = params;
+
+  const mutationScopeOption = resolver.options.mutationScope;
+  if (mutationScopeOption && typeof mutationScopeOption === "object") {
+    if ("include" in mutationScopeOption && "exclude" in mutationScopeOption) {
+      throw new Error("mutationScope cannot specify both 'include' and 'exclude'");
+    }
+  }
+
   const inlineEndpoints = shouldInlineEndpointsForTag(tag, resolver.options);
   const endpoints = data.get(tag)?.endpoints;
   if (!endpoints || endpoints.length === 0) {
@@ -938,7 +946,19 @@ function renderMutation({
     : endpointParams;
 
   const isPost = endpoint.method === "post";
-  const scopeEnabled = !!resolver.options.mutationScope && !isPost;
+  const mutationScopeOption = resolver.options.mutationScope;
+  const operationId = getEndpointName(endpoint);
+  const scopeMatchKey = `${tag}/${operationId}`;
+  let scopeEnabled = false;
+  if (!isPost && mutationScopeOption) {
+    if (mutationScopeOption === true) {
+      scopeEnabled = true;
+    } else if (typeof mutationScopeOption === "object" && "include" in mutationScopeOption) {
+      scopeEnabled = mutationScopeOption.include.some((id) => id === operationId || id === scopeMatchKey);
+    } else if (typeof mutationScopeOption === "object" && "exclude" in mutationScopeOption) {
+      scopeEnabled = !mutationScopeOption.exclude.some((id) => id === operationId || id === scopeMatchKey);
+    }
+  }
   const scopePathParams = scopeEnabled
     ? mapEndpointParamsToFunctionParams(resolver, endpoint, {}).filter((p) => p.paramType === "Path")
     : [];

--- a/src/generators/types/options.ts
+++ b/src/generators/types/options.ts
@@ -29,7 +29,7 @@ interface QueriesGenerateOptions {
   mutationDefaultOnError?: boolean;
   workspaceContext?: string[];
   prefetchQueries?: boolean;
-  mutationScope?: boolean;
+  mutationScope?: boolean | { include: string[] } | { exclude: string[] };
 }
 
 interface InfiniteQueriesGenerateOptions {


### PR DESCRIPTION
## Summary

* Extends `mutationScope` to accept `{ include: string[] }` or `{ exclude: string[] }` in addition to `boolean`
* Supports `"Tag/operationId"` format for precise per-operation control, or plain `"operationId"` to match across all tags
* Throws a clear error if both `include` and `exclude` are specified together

## Motivation

Some endpoints can't use resource-scoped mutations because the path param is only known at `mutate()` time (e.g. a generic key-value settings hook). Previously there was no way to opt these out while keeping the rest scoped.

With `exclude`, one config entry handles it:

```ts
mutationScope: { exclude: ["EmployeeSettings/update"] }
```

With `include`, teams that want surgical control can scope only specific operations without touching the rest:

```ts
mutationScope: { include: ["Projects/update", "Documents/update"] }
```

## Test plan

* `mutationScope: true` — existing behaviour unchanged, all non-POST mutations scoped
* `mutationScope: { include: ["Tag/operationId"] }` — only listed operation gets path param lifting + scope
* `mutationScope: { exclude: ["Tag/operationId"] }` — all operations scoped except listed
* `mutationScope: { include: [...], exclude: [...] }` — throws error at generation time
* Run `pnpm test` — 17/18 pass (pre-existing failure unrelated)
