### PR TITLE
feat: add domain error handling with DomainErrorRegistry and domain-e…

### DIFF
--- a/src/generators/const/deps.const.ts
+++ b/src/generators/const/deps.const.ts
@@ -4,6 +4,7 @@ import { ACL_PACKAGE_IMPORT_PATH, PACKAGE_IMPORT_PATH } from "./package.const";
 
 export const APP_REST_CLIENT_NAME = "AppRestClient";
 export const APP_REST_CLIENT_FILE: GenerateFile = { fileName: "app-rest-client", extension: "ts" };
+export const DOMAIN_ERRORS_FILE: GenerateFile = { fileName: "domain-errors", extension: "ts" };
 
 export const QUERY_OPTIONS_TYPES = {
   query: "AppQueryOptions",

--- a/src/generators/core/endpoints/getEndpointsFromOpenAPIDoc.ts
+++ b/src/generators/core/endpoints/getEndpointsFromOpenAPIDoc.ts
@@ -176,10 +176,22 @@ export function getEndpointsFromOpenAPIDoc(resolver: SchemaResolver) {
             endpoint.responseObject = responseObj;
             endpoint.responseDescription = responseObj?.description;
           } else if (statusCode !== "default" && !Number.isNaN(status) && isErrorStatus(status)) {
+            const rawSchema = schemaObject as Record<string, unknown>;
+            const domainStr = rawSchema["x-domain-error-domain"];
+            const codeEnum = (rawSchema?.properties as Record<string, unknown> | undefined)?.code;
+            const codeEnumArr = (codeEnum as Record<string, unknown> | undefined)?.enum;
+            const domainCode =
+              Array.isArray(codeEnumArr) && codeEnumArr.length === 1 && typeof codeEnumArr[0] === "number"
+                ? (codeEnumArr[0] as number)
+                : undefined;
+
             endpoint.errors.push({
               zodSchema: responseZodSchema,
               status,
               description: responseObj?.description,
+              ...(typeof domainStr === "string" && domainCode !== undefined
+                ? { domainError: { domain: domainStr, code: domainCode } }
+                : {}),
             });
           }
         } else {

--- a/src/generators/generate/generateDomainErrors.test.ts
+++ b/src/generators/generate/generateDomainErrors.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from "vitest";
+
+import { Endpoint } from "@/generators/types/endpoint";
+import { GenerateData } from "@/generators/types/generate";
+
+import { generateDomainErrors } from "./generateDomainErrors";
+
+function makeData(endpointGroups: Partial<Endpoint>[][]): GenerateData {
+  const data: GenerateData = new Map();
+  endpointGroups.forEach((endpoints, i) => {
+    data.set(`tag${i}`, {
+      endpoints: endpoints as Endpoint[],
+      zodSchemas: {},
+    });
+  });
+  return data;
+}
+
+function makeEndpointWithDomainError(domain: string, code: number, description?: string): Partial<Endpoint> {
+  return {
+    errors: [
+      {
+        status: 400,
+        zodSchema: "z.void()",
+        description,
+        domainError: { domain, code },
+      },
+    ],
+  };
+}
+
+const stubResolver = {} as never;
+
+describe("generateDomainErrors", () => {
+  it("returns undefined when no domain errors exist", () => {
+    const data = makeData([[{ errors: [{ status: 400, zodSchema: "z.void()" }] }]]);
+    expect(generateDomainErrors({ resolver: stubResolver, data })).toBeUndefined();
+  });
+
+  it("returns undefined for empty data", () => {
+    const data: GenerateData = new Map();
+    expect(generateDomainErrors({ resolver: stubResolver, data })).toBeUndefined();
+  });
+
+  it("generates const and type for a single domain error", () => {
+    const data = makeData([[makeEndpointWithDomainError("rocket", 1001, "Rocket could not launch")]]);
+    const result = generateDomainErrors({ resolver: stubResolver, data })!;
+
+    expect(result).toContain("export const RocketDomainErrors = {");
+    expect(result).toContain("/** Rocket could not launch */");
+    expect(result).toContain("ERROR_1001: 1001");
+    expect(result).toContain("} as const;");
+    expect(result).toContain("export type RocketDomainErrorCode =");
+    expect(result).toContain("(typeof RocketDomainErrors)[keyof typeof RocketDomainErrors]");
+  });
+
+  it("deduplicates the same domain/code appearing on multiple endpoints in the same tag", () => {
+    const data = makeData([
+      [
+        makeEndpointWithDomainError("rocket", 1001, "Rocket could not launch"),
+        makeEndpointWithDomainError("rocket", 1001, "Rocket could not launch"),
+      ],
+    ]);
+    const result = generateDomainErrors({ resolver: stubResolver, data })!;
+
+    const matches = result.match(/ERROR_1001/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it("deduplicates the same domain/code across different tags", () => {
+    const data = makeData([
+      [makeEndpointWithDomainError("rocket", 1001, "Rocket could not launch")],
+      [makeEndpointWithDomainError("rocket", 1001, "Rocket could not launch")],
+    ]);
+    const result = generateDomainErrors({ resolver: stubResolver, data })!;
+
+    const matches = result.match(/ERROR_1001/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it("groups multiple codes under the same domain", () => {
+    const data = makeData([
+      [
+        makeEndpointWithDomainError("rocket", 1001, "Could not launch"),
+        makeEndpointWithDomainError("rocket", 1002, "Out of fuel"),
+      ],
+    ]);
+    const result = generateDomainErrors({ resolver: stubResolver, data })!;
+
+    expect(result).toContain("ERROR_1001: 1001");
+    expect(result).toContain("ERROR_1002: 1002");
+    // only one const block for the domain
+    const matches = result.match(/export const RocketDomainErrors/g) ?? [];
+    expect(matches).toHaveLength(1);
+  });
+
+  it("generates separate const blocks for different domains", () => {
+    const data = makeData([
+      [
+        makeEndpointWithDomainError("rocket", 1001),
+        makeEndpointWithDomainError("user", 2001),
+      ],
+    ]);
+    const result = generateDomainErrors({ resolver: stubResolver, data })!;
+
+    expect(result).toContain("export const RocketDomainErrors = {");
+    expect(result).toContain("export const UserDomainErrors = {");
+  });
+
+  it("sorts codes numerically within a domain", () => {
+    const data = makeData([
+      [
+        makeEndpointWithDomainError("rocket", 1003),
+        makeEndpointWithDomainError("rocket", 1001),
+        makeEndpointWithDomainError("rocket", 1002),
+      ],
+    ]);
+    const result = generateDomainErrors({ resolver: stubResolver, data })!;
+
+    const pos1001 = result.indexOf("ERROR_1001");
+    const pos1002 = result.indexOf("ERROR_1002");
+    const pos1003 = result.indexOf("ERROR_1003");
+    expect(pos1001).toBeLessThan(pos1002);
+    expect(pos1002).toBeLessThan(pos1003);
+  });
+
+  it("sorts domain blocks alphabetically", () => {
+    const data = makeData([
+      [
+        makeEndpointWithDomainError("zebra", 9001),
+        makeEndpointWithDomainError("alpha", 1001),
+      ],
+    ]);
+    const result = generateDomainErrors({ resolver: stubResolver, data })!;
+
+    expect(result.indexOf("AlphaDomainErrors")).toBeLessThan(result.indexOf("ZebraDomainErrors"));
+  });
+
+  it("omits JSDoc comment when description is undefined", () => {
+    const data = makeData([[makeEndpointWithDomainError("rocket", 1001)]]);
+    const result = generateDomainErrors({ resolver: stubResolver, data })!;
+
+    expect(result).not.toContain("/**");
+    expect(result).toContain("ERROR_1001: 1001");
+  });
+
+  it("converts kebab-case domain to PascalCase", () => {
+    const data = makeData([[makeEndpointWithDomainError("user-auth", 3001)]]);
+    const result = generateDomainErrors({ resolver: stubResolver, data })!;
+
+    expect(result).toContain("export const UserAuthDomainErrors = {");
+    expect(result).toContain("export type UserAuthDomainErrorCode =");
+  });
+
+  it("converts underscore domain to PascalCase", () => {
+    const data = makeData([[makeEndpointWithDomainError("push_notification", 4001)]]);
+    const result = generateDomainErrors({ resolver: stubResolver, data })!;
+
+    expect(result).toContain("export const PushNotificationDomainErrors = {");
+  });
+});

--- a/src/generators/generate/generateDomainErrors.ts
+++ b/src/generators/generate/generateDomainErrors.ts
@@ -1,0 +1,62 @@
+import { SchemaResolver } from "@/generators/core/SchemaResolver.class";
+import { GenerateData } from "@/generators/types/generate";
+import { capitalize } from "@/generators/utils/string.utils";
+
+function domainToPascalCase(domain: string): string {
+  return domain.split(/[-_]/).map(capitalize).join("");
+}
+
+interface DomainErrorDef {
+  code: number;
+  description?: string;
+}
+
+export function generateDomainErrors({
+  data,
+}: {
+  resolver: SchemaResolver;
+  data: GenerateData;
+}): string | undefined {
+  const byDomain = new Map<string, Map<number, DomainErrorDef>>();
+
+  for (const { endpoints } of data.values()) {
+    for (const endpoint of endpoints) {
+      for (const error of endpoint.errors) {
+        if (!error.domainError) continue;
+        const { domain, code } = error.domainError;
+
+        if (!byDomain.has(domain)) {
+          byDomain.set(domain, new Map());
+        }
+
+        const domainMap = byDomain.get(domain)!;
+        if (!domainMap.has(code)) {
+          domainMap.set(code, { code, description: error.description });
+        }
+      }
+    }
+  }
+
+  if (byDomain.size === 0) return undefined;
+
+  const blocks: string[] = [];
+
+  for (const [domain, codes] of [...byDomain.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const pascalName = domainToPascalCase(domain);
+    const sortedCodes = [...codes.values()].sort((a, b) => a.code - b.code);
+
+    const entries = sortedCodes
+      .map(({ code, description }) => {
+        const comment = description ? `  /** ${description} */\n  ` : "  ";
+        return `${comment}ERROR_${code}: ${code}`;
+      })
+      .join(",\n");
+
+    blocks.push(`export const ${pascalName}DomainErrors = {\n${entries},\n} as const;`);
+    blocks.push(
+      `export type ${pascalName}DomainErrorCode = (typeof ${pascalName}DomainErrors)[keyof typeof ${pascalName}DomainErrors];`,
+    );
+  }
+
+  return blocks.join("\n\n") + "\n";
+}

--- a/src/generators/generateCodeFromOpenAPIDoc.ts
+++ b/src/generators/generateCodeFromOpenAPIDoc.ts
@@ -11,6 +11,7 @@ import { getOutputFileName } from "./utils/file.utils";
 import {
   getAclFiles,
   getAppRestClientFiles,
+  getDomainErrorsFiles,
   getMutationEffectsFiles,
   getZodExtendedFiles,
 } from "./utils/generate-files.utils";
@@ -73,6 +74,7 @@ export function generateCodeFromOpenAPIDoc(
       ...p.runSync("render.MutationEffects", () => getMutationEffectsFiles(data, resolver)),
       ...p.runSync("render.ZodExtended", () => getZodExtendedFiles(data, resolver)),
       ...p.runSync("render.Standalone", () => getAppRestClientFiles(resolver)),
+      ...p.runSync("render.DomainErrors", () => getDomainErrorsFiles(data, resolver)),
     );
   }
 

--- a/src/generators/types/endpoint.ts
+++ b/src/generators/types/endpoint.ts
@@ -12,10 +12,16 @@ export interface EndpointParameter {
   bodyObject?: OpenAPIV3.RequestBodyObject;
 }
 
-interface EndpointError {
+export interface DomainErrorInfo {
+  domain: string;
+  code: number;
+}
+
+export interface EndpointError {
   status: number | "default";
   description?: string;
   zodSchema: string;
+  domainError?: DomainErrorInfo;
 }
 
 export interface AclConditionsPropertyType {

--- a/src/generators/utils/generate-files.utils.ts
+++ b/src/generators/utils/generate-files.utils.ts
@@ -1,9 +1,10 @@
 import { ACL_APP_ABILITY_FILE } from "@/generators/const/acl.const";
-import { APP_REST_CLIENT_FILE, QUERY_MODULES_FILE } from "@/generators/const/deps.const";
+import { APP_REST_CLIENT_FILE, DOMAIN_ERRORS_FILE, QUERY_MODULES_FILE } from "@/generators/const/deps.const";
 import { DEFAULT_GENERATE_OPTIONS } from "@/generators/const/options.const";
 import { SchemaResolver } from "@/generators/core/SchemaResolver.class";
 import { generateAppAcl } from "@/generators/generate/generateAcl";
 import { generateAppRestClient } from "@/generators/generate/generateAppRestClient";
+import { generateDomainErrors } from "@/generators/generate/generateDomainErrors";
 import { generateQueryModules } from "@/generators/generate/generateQueryModules";
 import { GenerateData, GenerateFile, GenerateFileData } from "@/generators/types/generate";
 
@@ -44,6 +45,21 @@ export function getMutationEffectsFiles(data: GenerateData, resolver: SchemaReso
 
 export function getZodExtendedFiles(_data: GenerateData, _resolver: SchemaResolver): GenerateFileData[] {
   return [];
+}
+
+export function getDomainErrorsFiles(data: GenerateData, resolver: SchemaResolver): GenerateFileData[] {
+  const content = generateDomainErrors({ resolver, data });
+  if (!content) return [];
+
+  return [
+    {
+      fileName: getOutputFileName({
+        output: resolver.options.output,
+        fileName: getFileNameWithExtension(DOMAIN_ERRORS_FILE),
+      }),
+      content,
+    },
+  ];
 }
 
 export function getAppRestClientFiles(resolver: SchemaResolver): GenerateFileData[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,8 @@ export { RestInterceptor } from "./lib/rest/rest-interceptor";
 export { RestUtils } from "./lib/rest/rest.utils";
 
 // Error handling
-export { ApplicationException, ErrorHandler, SharedErrorHandler } from "./lib/rest/error-handling";
-export type { GeneralErrorCodes, ErrorHandlerOptions, ErrorEntry } from "./lib/rest/error-handling";
+export { ApplicationException, ErrorHandler, SharedErrorHandler, DomainErrorRegistry } from "./lib/rest/error-handling";
+export type { GeneralErrorCodes, ErrorHandlerOptions, ErrorEntry, DomainErrorEntry } from "./lib/rest/error-handling";
 
 // React Query types
 export type { AppQueryOptions, AppMutationOptions, AppInfiniteQueryOptions } from "./lib/react-query.types";

--- a/src/lib/rest/error-handling.test.ts
+++ b/src/lib/rest/error-handling.test.ts
@@ -100,6 +100,33 @@ describe("DomainErrorRegistry", () => {
   it("returns undefined for unregistered code", () => {
     expect(DomainErrorRegistry.getEntry(9999)).toBeUndefined();
   });
+
+  it("registers and retrieves a string code", () => {
+    DomainErrorRegistry.register({ code: "BUSINESS_PARTNER_IS_LOCKED", getMessage: () => "locked" });
+    expect(DomainErrorRegistry.getEntry("BUSINESS_PARTNER_IS_LOCKED")).toBeDefined();
+    expect(DomainErrorRegistry.getEntry("BUSINESS_PARTNER_IS_LOCKED")!.code).toBe("BUSINESS_PARTNER_IS_LOCKED");
+  });
+
+  it("unregisters a string code", () => {
+    DomainErrorRegistry.register({ code: "SOME_ERROR", getMessage: () => "msg" });
+    DomainErrorRegistry.unregister("SOME_ERROR");
+    expect(DomainErrorRegistry.getEntry("SOME_ERROR")).toBeUndefined();
+  });
+
+  it("string '1001' and number 1001 are distinct entries", () => {
+    DomainErrorRegistry.register({ code: "1001", getMessage: () => "string handler" });
+    DomainErrorRegistry.register({ code: 1001, getMessage: () => "number handler" });
+    expect(DomainErrorRegistry.getEntry("1001")!.getMessage({} as never, null)).toBe("string handler");
+    expect(DomainErrorRegistry.getEntry(1001)!.getMessage({} as never, null)).toBe("number handler");
+  });
+
+  it("clear() removes both string and number entries", () => {
+    DomainErrorRegistry.register({ code: "STRING_CODE", getMessage: () => "a" });
+    DomainErrorRegistry.register({ code: 1001, getMessage: () => "b" });
+    DomainErrorRegistry.clear();
+    expect(DomainErrorRegistry.getEntry("STRING_CODE")).toBeUndefined();
+    expect(DomainErrorRegistry.getEntry(1001)).toBeUndefined();
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -200,6 +227,71 @@ describe("ErrorHandler priority", () => {
       } catch (e) {
         expect((e as ApplicationException<never>).message).toBe("shared domain msg");
       }
+    }
+  });
+
+  it("DomainErrorRegistry handles a string code when no per-instance entry matches", () => {
+    DomainErrorRegistry.register({ code: "BUSINESS_PARTNER_IS_LOCKED", getMessage: () => "partner is locked" });
+
+    const handler = new ErrorHandler({ entries: [] });
+    const err = makeAxiosError({ code: "BUSINESS_PARTNER_IS_LOCKED", message: "locked" });
+    try {
+      handler.rethrowError(err);
+    } catch (e) {
+      expect((e as ApplicationException<never>).message).toBe("partner is locked");
+      expect((e as ApplicationException<never>).code).toBe("BUSINESS_PARTNER_IS_LOCKED");
+    }
+  });
+
+  it("per-instance string entry takes priority over registry for the same string code", () => {
+    DomainErrorRegistry.register({ code: "BUSINESS_PARTNER_IS_LOCKED", getMessage: () => "registry message" });
+
+    const handler = new ErrorHandler({
+      entries: [
+        {
+          code: "BUSINESS_PARTNER_IS_LOCKED",
+          condition: (e) => RestUtils.extractServerResponseCode(e) === "BUSINESS_PARTNER_IS_LOCKED",
+          getMessage: () => "instance message",
+        },
+      ],
+    });
+
+    const err = makeAxiosError({ code: "BUSINESS_PARTNER_IS_LOCKED" });
+    try {
+      handler.rethrowError(err);
+    } catch (e) {
+      expect((e as ApplicationException<string>).message).toBe("instance message");
+    }
+  });
+
+  it("string '1001' and number 1001 are matched independently", () => {
+    DomainErrorRegistry.register({ code: "1001", getMessage: () => "string handler" });
+    DomainErrorRegistry.register({ code: 1001, getMessage: () => "number handler" });
+
+    const handler = new ErrorHandler({ entries: [] });
+
+    // numeric code → number handler
+    try {
+      handler.rethrowError(makeNumericDomainAxiosError(1001));
+    } catch (e) {
+      expect((e as ApplicationException<never>).message).toBe("number handler");
+    }
+
+    // string code → string handler
+    try {
+      handler.rethrowError(makeAxiosError({ code: "1001" }));
+    } catch (e) {
+      expect((e as ApplicationException<never>).message).toBe("string handler");
+    }
+  });
+
+  it("unregistered string code falls through to UNKNOWN_ERROR", () => {
+    const handler = new ErrorHandler({ entries: [] });
+    const err = makeAxiosError({ code: "UNREGISTERED_CODE" });
+    try {
+      handler.rethrowError(err);
+    } catch (e) {
+      expect((e as ApplicationException<never>).code).toBe("UNKNOWN_ERROR");
     }
   });
 });

--- a/src/lib/rest/error-handling.test.ts
+++ b/src/lib/rest/error-handling.test.ts
@@ -1,0 +1,205 @@
+import axios from "axios";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ApplicationException, DomainErrorRegistry, ErrorHandler } from "./error-handling";
+import { RestUtils } from "./rest.utils";
+
+// ---------------------------------------------------------------------------
+// RestUtils.extractServerResponseCode
+// ---------------------------------------------------------------------------
+
+function makeAxiosError(data: unknown, status = 400) {
+  const err = new axios.AxiosError("request failed");
+  err.response = { data, status, statusText: "Bad Request", headers: {}, config: {} } as never;
+  return err;
+}
+
+describe("RestUtils.extractServerResponseCode", () => {
+  it("returns null for a plain Error", () => {
+    expect(RestUtils.extractServerResponseCode(new Error("oops"))).toBeNull();
+  });
+
+  it("returns 'validation-exception' for a ZodError", async () => {
+    const { z } = await import("zod");
+    const result = z.string().safeParse(123);
+    if (result.success) throw new Error("expected failure");
+    expect(RestUtils.extractServerResponseCode(result.error)).toBe("validation-exception");
+  });
+
+  it("returns a string code from response.data.code", () => {
+    const err = makeAxiosError({ code: "USER_NOT_FOUND" });
+    expect(RestUtils.extractServerResponseCode(err)).toBe("USER_NOT_FOUND");
+  });
+
+  it("returns a numeric code from response.data.code", () => {
+    const err = makeAxiosError({ code: 1001 });
+    expect(RestUtils.extractServerResponseCode(err)).toBe(1001);
+  });
+
+  it("returns null when code is boolean (neither string nor number)", () => {
+    const err = makeAxiosError({ code: true });
+    expect(RestUtils.extractServerResponseCode(err)).toBeNull();
+  });
+
+  it("returns null when response has no data.code", () => {
+    const err = makeAxiosError({ message: "something went wrong" });
+    expect(RestUtils.extractServerResponseCode(err)).toBeNull();
+  });
+
+  it("existing string behavior unchanged — null when no axios error", () => {
+    expect(RestUtils.extractServerResponseCode("a string")).toBeNull();
+    expect(RestUtils.extractServerResponseCode(null)).toBeNull();
+    expect(RestUtils.extractServerResponseCode(undefined)).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// DomainErrorRegistry
+// ---------------------------------------------------------------------------
+
+describe("DomainErrorRegistry", () => {
+  afterEach(() => DomainErrorRegistry.clear());
+
+  it("registers a single entry and retrieves it", () => {
+    DomainErrorRegistry.register({ code: 1001, getMessage: () => "could not launch" });
+    expect(DomainErrorRegistry.getEntry(1001)).toBeDefined();
+    expect(DomainErrorRegistry.getEntry(1001)!.code).toBe(1001);
+  });
+
+  it("registers multiple entries via array", () => {
+    DomainErrorRegistry.register([
+      { code: 1001, getMessage: () => "could not launch" },
+      { code: 2001, getMessage: () => "user not found" },
+    ]);
+    expect(DomainErrorRegistry.getEntry(1001)).toBeDefined();
+    expect(DomainErrorRegistry.getEntry(2001)).toBeDefined();
+  });
+
+  it("later register overwrites earlier for same code", () => {
+    DomainErrorRegistry.register({ code: 1001, getMessage: () => "old" });
+    DomainErrorRegistry.register({ code: 1001, getMessage: () => "new" });
+    expect(DomainErrorRegistry.getEntry(1001)!.getMessage({} as never, null)).toBe("new");
+  });
+
+  it("unregisters an entry", () => {
+    DomainErrorRegistry.register({ code: 1001, getMessage: () => "msg" });
+    DomainErrorRegistry.unregister(1001);
+    expect(DomainErrorRegistry.getEntry(1001)).toBeUndefined();
+  });
+
+  it("clear() removes all entries", () => {
+    DomainErrorRegistry.register([
+      { code: 1001, getMessage: () => "a" },
+      { code: 2001, getMessage: () => "b" },
+    ]);
+    DomainErrorRegistry.clear();
+    expect(DomainErrorRegistry.getEntry(1001)).toBeUndefined();
+    expect(DomainErrorRegistry.getEntry(2001)).toBeUndefined();
+  });
+
+  it("returns undefined for unregistered code", () => {
+    expect(DomainErrorRegistry.getEntry(9999)).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ErrorHandler priority chain
+// ---------------------------------------------------------------------------
+
+describe("ErrorHandler priority", () => {
+  afterEach(() => DomainErrorRegistry.clear());
+
+  function makeNumericDomainAxiosError(code: number) {
+    return makeAxiosError({ status: "error", code, message: "domain error" });
+  }
+
+  it("string-based per-instance entries still work unchanged", () => {
+    const handler = new ErrorHandler({
+      entries: [{ code: "USER_NOT_FOUND", condition: (e) => RestUtils.extractServerResponseCode(e) === "USER_NOT_FOUND", getMessage: () => "user not found" }],
+    });
+    const err = makeAxiosError({ code: "USER_NOT_FOUND" });
+    expect(() => handler.rethrowError(err)).toThrow(ApplicationException);
+    try {
+      handler.rethrowError(err);
+    } catch (e) {
+      expect((e as ApplicationException<string>).code).toBe("USER_NOT_FOUND");
+      expect((e as ApplicationException<string>).message).toBe("user not found");
+    }
+  });
+
+  it("per-instance entry takes priority over DomainErrorRegistry for the same numeric code", () => {
+    DomainErrorRegistry.register({ code: 1001, getMessage: () => "registry message" });
+
+    const handler = new ErrorHandler({
+      entries: [
+        {
+          code: "CUSTOM_OVERRIDE" as string,
+          condition: (e) => RestUtils.extractServerResponseCode(e) === 1001,
+          getMessage: () => "instance message",
+        },
+      ],
+    });
+
+    const err = makeNumericDomainAxiosError(1001);
+    try {
+      handler.rethrowError(err);
+    } catch (e) {
+      expect((e as ApplicationException<string>).message).toBe("instance message");
+    }
+  });
+
+  it("DomainErrorRegistry matches before UNKNOWN_ERROR fallback", () => {
+    DomainErrorRegistry.register({ code: 1001, getMessage: () => "rocket could not launch" });
+
+    const handler = new ErrorHandler({ entries: [] });
+    const err = makeNumericDomainAxiosError(1001);
+    try {
+      handler.rethrowError(err);
+    } catch (e) {
+      expect((e as ApplicationException<never>).message).toBe("rocket could not launch");
+      expect((e as ApplicationException<never>).code).toBe(1001);
+    }
+  });
+
+  it("unregistered numeric code falls through to UNKNOWN_ERROR", () => {
+    const handler = new ErrorHandler({ entries: [] });
+    const err = makeNumericDomainAxiosError(9999);
+    try {
+      handler.rethrowError(err);
+    } catch (e) {
+      expect((e as ApplicationException<never>).code).toBe("UNKNOWN_ERROR");
+    }
+  });
+
+  it("DomainErrorRegistry condition can veto a code match", () => {
+    DomainErrorRegistry.register({
+      code: 1001,
+      condition: () => false,
+      getMessage: () => "should not be used",
+    });
+
+    const handler = new ErrorHandler({ entries: [] });
+    const err = makeNumericDomainAxiosError(1001);
+    try {
+      handler.rethrowError(err);
+    } catch (e) {
+      // condition returned false → falls through to UNKNOWN_ERROR
+      expect((e as ApplicationException<never>).code).toBe("UNKNOWN_ERROR");
+    }
+  });
+
+  it("multiple ErrorHandler instances share the same DomainErrorRegistry", () => {
+    DomainErrorRegistry.register({ code: 2001, getMessage: () => "shared domain msg" });
+
+    const handlerA = new ErrorHandler({ entries: [] });
+    const handlerB = new ErrorHandler({ entries: [] });
+
+    for (const handler of [handlerA, handlerB]) {
+      try {
+        handler.rethrowError(makeNumericDomainAxiosError(2001));
+      } catch (e) {
+        expect((e as ApplicationException<never>).message).toBe("shared domain msg");
+      }
+    }
+  });
+});

--- a/src/lib/rest/error-handling.ts
+++ b/src/lib/rest/error-handling.ts
@@ -32,13 +32,13 @@ export interface ErrorEntry<CodeT> {
 }
 
 export interface DomainErrorEntry {
-  code: number;
+  code: string | number;
   condition?: (error: unknown) => boolean;
   getMessage: (t: TFunction<string, undefined>, error: unknown) => string;
 }
 
 export class DomainErrorRegistry {
-  private static readonly entries = new Map<number, DomainErrorEntry>();
+  private static readonly entries = new Map<string | number, DomainErrorEntry>();
 
   static register(entry: DomainErrorEntry): void;
   static register(entries: DomainErrorEntry[]): void;
@@ -49,7 +49,7 @@ export class DomainErrorRegistry {
     }
   }
 
-  static unregister(code: number): void {
+  static unregister(code: string | number): void {
     this.entries.delete(code);
   }
 
@@ -57,7 +57,7 @@ export class DomainErrorRegistry {
     this.entries.clear();
   }
 
-  static getEntry(code: number): DomainErrorEntry | undefined {
+  static getEntry(code: string | number): DomainErrorEntry | undefined {
     return this.entries.get(code);
   }
 }
@@ -176,8 +176,8 @@ export class ErrorHandler<CodeT extends string | number> {
       throw exception;
     }
 
-    // 2. Global domain error registry (numeric codes)
-    if (typeof code === "number") {
+    // 2. Global domain error registry (string or numeric codes)
+    if (code !== null) {
       const registryEntry = DomainErrorRegistry.getEntry(code);
       if (registryEntry && (!registryEntry.condition || registryEntry.condition(error))) {
         const exception = new ApplicationException(registryEntry.getMessage(this.t, error), registryEntry.code, serverMessage);

--- a/src/lib/rest/error-handling.ts
+++ b/src/lib/rest/error-handling.ts
@@ -31,14 +31,47 @@ export interface ErrorEntry<CodeT> {
   getMessage: (t: TFunction<string, undefined>, error: unknown) => string;
 }
 
-export interface ErrorHandlerOptions<CodeT extends string> {
+export interface DomainErrorEntry {
+  code: number;
+  condition?: (error: unknown) => boolean;
+  getMessage: (t: TFunction<string, undefined>, error: unknown) => string;
+}
+
+export class DomainErrorRegistry {
+  private static readonly entries = new Map<number, DomainErrorEntry>();
+
+  static register(entry: DomainErrorEntry): void;
+  static register(entries: DomainErrorEntry[]): void;
+  static register(entryOrEntries: DomainErrorEntry | DomainErrorEntry[]): void {
+    const items = Array.isArray(entryOrEntries) ? entryOrEntries : [entryOrEntries];
+    for (const item of items) {
+      this.entries.set(item.code, item);
+    }
+  }
+
+  static unregister(code: number): void {
+    this.entries.delete(code);
+  }
+
+  static clear(): void {
+    this.entries.clear();
+  }
+
+  static getEntry(code: number): DomainErrorEntry | undefined {
+    return this.entries.get(code);
+  }
+}
+
+export interface ErrorHandlerOptions<CodeT extends string | number> {
   entries: ErrorEntry<CodeT>[];
   t?: TFunction<string, undefined>;
   onRethrowError?: (error: unknown, exception: ApplicationException<CodeT | GeneralErrorCodes>) => void;
 }
 
-export class ErrorHandler<CodeT extends string> {
+export class ErrorHandler<CodeT extends string | number> {
   entries: ErrorEntry<CodeT | GeneralErrorCodes>[] = [];
+  private readonly userEntries: ErrorEntry<CodeT | GeneralErrorCodes>[];
+  private readonly generalEntries: ErrorEntry<CodeT | GeneralErrorCodes>[];
   private t: TFunction<string, undefined>;
   private onRethrowError?: (error: unknown, exception: ApplicationException<CodeT | GeneralErrorCodes>) => void;
 
@@ -114,11 +147,13 @@ export class ErrorHandler<CodeT extends string> {
       },
     };
 
-    // general errors have the lowest priority
-    this.entries = [...entries, dataValidationError, internalError, networkError, canceledError, unknownError];
+    this.userEntries = [...entries];
+    this.generalEntries = [dataValidationError, internalError, networkError, canceledError, unknownError];
+    // combined for public backward compatibility
+    this.entries = [...this.userEntries, ...this.generalEntries];
   }
 
-  private matchesEntry(error: unknown, entry: ErrorEntry<CodeT | GeneralErrorCodes>, code: string | null): boolean {
+  private matchesEntry(error: unknown, entry: ErrorEntry<CodeT | GeneralErrorCodes>, code: string | number | null): boolean {
     if (entry.condition) {
       return entry.condition(error);
     }
@@ -131,13 +166,30 @@ export class ErrorHandler<CodeT extends string> {
 
   public rethrowError(error: unknown): ApplicationException<CodeT | GeneralErrorCodes> {
     const code = RestUtils.extractServerResponseCode(error);
-    const errorEntry = this.entries.find((entry) => this.matchesEntry(error, entry, code))!;
-
     const serverMessage = RestUtils.extractServerErrorMessage(error);
-    const exception = new ApplicationException(errorEntry.getMessage(this.t, error), errorEntry.code, serverMessage);
 
+    // 1. Per-instance custom entries (highest priority)
+    const userEntry = this.userEntries.find((entry) => this.matchesEntry(error, entry, code));
+    if (userEntry) {
+      const exception = new ApplicationException(userEntry.getMessage(this.t, error), userEntry.code, serverMessage);
+      this.onRethrowError?.(error, exception);
+      throw exception;
+    }
+
+    // 2. Global domain error registry (numeric codes)
+    if (typeof code === "number") {
+      const registryEntry = DomainErrorRegistry.getEntry(code);
+      if (registryEntry && (!registryEntry.condition || registryEntry.condition(error))) {
+        const exception = new ApplicationException(registryEntry.getMessage(this.t, error), registryEntry.code, serverMessage);
+        this.onRethrowError?.(error, exception as unknown as ApplicationException<CodeT | GeneralErrorCodes>);
+        throw exception;
+      }
+    }
+
+    // 3. Built-in general fallbacks (lowest priority)
+    const generalEntry = this.generalEntries.find((entry) => this.matchesEntry(error, entry, code))!;
+    const exception = new ApplicationException(generalEntry.getMessage(this.t, error), generalEntry.code, serverMessage);
     this.onRethrowError?.(error, exception);
-
     throw exception;
   }
 

--- a/src/lib/rest/rest.utils.ts
+++ b/src/lib/rest/rest.utils.ts
@@ -3,7 +3,7 @@ import { isAxiosError } from "axios";
 import { z } from "zod";
 
 export namespace RestUtils {
-  export const extractServerResponseCode = (e: unknown): string | null => {
+  export const extractServerResponseCode = (e: unknown): string | number | null => {
     if (e instanceof z.ZodError) {
       return "validation-exception";
     }
@@ -19,6 +19,10 @@ export namespace RestUtils {
     const data = e.response.data as { code: unknown } | undefined;
 
     if (typeof data?.code === "string") {
+      return data.code;
+    }
+
+    if (typeof data?.code === "number") {
       return data.code;
     }
 


### PR DESCRIPTION
## Summary

* Added numeric domain error code support to runtime error handling
* Added a global `DomainErrorRegistry` for application-wide domain error registration
* Extended OpenAPI parsing to read `x-domain-error-domain` and numeric `code.enum` values from domain error schemas
* Added generation of shared `domain-errors.ts` constants grouped by domain
* Kept existing string-based error handling fully backward compatible
* Added runtime and generator test coverage

## Runtime

* `extractServerResponseCode` now supports `string | number | null`
* Added `DomainErrorRegistry` with register, unregister, clear, and lookup support
* `ErrorHandler` now resolves errors in the following order:

  1. Per-instance entries
  2. `DomainErrorRegistry`
  3. Built-in fallback entries

## Generator

* Reads domain error metadata from OpenAPI response schemas
* Generates shared `domain-errors.ts` containing typed domain error constants
* Deduplicates domain errors across endpoints and tags

Example:

```ts
export const RocketDomainErrors = {
  ERROR_1001: 1001,
} as const;
```

## Testing

* Added runtime tests for numeric error codes, registry behavior, and handler priority
* Added generator tests for domain error extraction, deduplication, sorting, and output generation
