### PR TITLE
fix: resolve generated query TypeScript errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@povio/openapi-codegen-cli",
-  "version": "3.0.0-rc.2",
+  "version": "3.0.0-rc.3",
   "keywords": [
     "codegen",
     "openapi",

--- a/src/generators/generate/generateQueries.test.ts
+++ b/src/generators/generate/generateQueries.test.ts
@@ -310,3 +310,114 @@ describe("generateQueries workspaceContext", () => {
     expect(queriesFile?.content).toContain("onError: options?.onError ?? queryConfig.onError");
   });
 });
+
+const paginatedDoc = {
+  openapi: "3.0.0",
+  info: { title: "Paginated Test", version: "1.0.0" },
+  paths: {
+    "/items": {
+      get: {
+        tags: ["items"],
+        operationId: "listItems",
+        parameters: [
+          { name: "page", in: "query", schema: { type: "integer" } },
+          { name: "limit", in: "query", schema: { type: "integer" } },
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/ItemsPage" } } },
+          },
+        },
+      } as OpenAPIV3.OperationObject,
+      post: {
+        tags: ["items"],
+        operationId: "createItem",
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { $ref: "#/components/schemas/Item" } } },
+        },
+        responses: {
+          "201": {
+            description: "Created",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/Item" } } },
+          },
+        },
+      } as OpenAPIV3.OperationObject,
+    },
+  },
+  components: {
+    schemas: {
+      Item: {
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      },
+      ItemsPage: {
+        type: "object",
+        properties: {
+          items: { type: "array", items: { $ref: "#/components/schemas/Item" } },
+          page: { type: "integer" },
+          totalItems: { type: "integer" },
+          limit: { type: "integer" },
+        },
+        required: ["items", "totalItems", "limit"],
+      },
+    },
+  },
+} as OpenAPIV3.Document;
+
+describe("generateQueries mutationEffects + infiniteQuery", () => {
+  it("emits QueryModule.tag (no typeof) in useMutationEffects type arg", () => {
+    const files = generateCodeFromOpenAPIDoc(paginatedDoc, {
+      ...DEFAULT_GENERATE_OPTIONS,
+      output: "test-output",
+      mutationEffects: true,
+      infiniteQueries: true,
+      acl: false,
+      checkAcl: false,
+      builderConfigs: false,
+      prefetchQueries: false,
+    });
+
+    const queriesFile = files.find((file) => file.fileName.endsWith("/items/items.queries.ts"));
+
+    // Bug 1: const enum must be referenced directly, not via typeof
+    expect(queriesFile?.content).toContain("useMutationEffects<QueryModule.items>");
+    expect(queriesFile?.content).not.toContain("useMutationEffects<typeof QueryModule.items>");
+
+    // Bug 2: MutationEffectsOptions must have no type arg so invalidateModules stays QueryModule[] (cross-module capable)
+    expect(queriesFile?.content).toContain("& MutationEffectsOptions)");
+    expect(queriesFile?.content).not.toContain("MutationEffectsOptions<QueryModule");
+
+    // Bug 3: getNextPageParam parameter has an explicit type annotation (no implicit any)
+    expect(queriesFile?.content).toContain("}: Awaited<ReturnType<typeof ItemsApi.list>>)");
+    // queryFn retains precise pageParam: number typing
+    expect(queriesFile?.content).toContain("queryFn: ({ pageParam }: { pageParam: number })");
+    // no unknown casts or pages: 1 in the shared options factory
+    expect(queriesFile?.content).not.toContain("pageParam: unknown");
+    expect(queriesFile?.content).not.toContain("pages: 1,");
+  });
+
+  it("prefetchInfiniteQuery casts options to {} and emits no pages", () => {
+    const files = generateCodeFromOpenAPIDoc(paginatedDoc, {
+      ...DEFAULT_GENERATE_OPTIONS,
+      output: "test-output",
+      mutationEffects: false,
+      infiniteQueries: true,
+      prefetchQueries: true,
+      acl: false,
+      checkAcl: false,
+      builderConfigs: false,
+    });
+
+    const queriesFile = files.find((file) => file.fileName.endsWith("/items/items.queries.ts"));
+
+    // options is cast to {} so it contributes no typed properties to the spread; without the cast
+    // the options type defaults prefetchInfiniteQuery generics to unknown, which conflicts with the
+    // generated queryFn expecting pageParam: number.
+    expect(queriesFile?.content).toContain("...(options as {})");
+    // no pages emitted anywhere
+    expect(queriesFile?.content).not.toContain("pages:");
+  });
+});

--- a/src/generators/generate/generateQueries.ts
+++ b/src/generators/generate/generateQueries.ts
@@ -797,7 +797,7 @@ function renderInfiniteQueryOptions({
   );
   lines.push("  initialPageParam: 1,");
   lines.push(
-    `  getNextPageParam: ({ ${resolver.options.infiniteQueryResponseParamNames.page}, ${resolver.options.infiniteQueryResponseParamNames.totalItems}, ${resolver.options.infiniteQueryResponseParamNames.limit}: limitParam }) => {`,
+    `  getNextPageParam: ({ ${resolver.options.infiniteQueryResponseParamNames.page}, ${resolver.options.infiniteQueryResponseParamNames.totalItems}, ${resolver.options.infiniteQueryResponseParamNames.limit}: limitParam }: Awaited<ReturnType<typeof ${endpointFunction}>>) => {`,
   );
   lines.push(`    const pageParam = ${resolver.options.infiniteQueryResponseParamNames.page} ?? 1;`);
   lines.push(
@@ -835,13 +835,18 @@ function renderPrefetchInfiniteQuery({ resolver, endpoint }: { resolver: SchemaR
     modelNamespaceTag: tag,
   });
   const endpointArgs = renderEndpointArgs(resolver, endpoint, { excludePageParam: true });
+  const optionsArgs = `${endpointParams ? `{ ${endpointArgs} }` : ""}${hasAxiosRequestConfig ? `${endpointParams ? ", " : ""}${AXIOS_REQUEST_CONFIG_NAME}` : ""}`;
 
   const lines: string[] = [];
   lines.push(
     `export const ${getPrefetchInfiniteQueryName(endpoint)} = (queryClient: QueryClient, ${endpointParams ? `{ ${endpointArgs} }: { ${endpointParams} }, ` : ""}${hasAxiosRequestConfig ? `${AXIOS_REQUEST_CONFIG_NAME}: ${AXIOS_REQUEST_CONFIG_TYPE}, ` : ""}options?: Omit<Parameters<QueryClient["prefetchInfiniteQuery"]>[0], "queryKey" | "queryFn" | "initialPageParam" | "getNextPageParam">): void => {`,
   );
+  // options is cast to {} so it contributes no typed properties to the spread, letting TypeScript
+  // infer TPageParam and TQueryFnData solely from the options factory (via initialPageParam and
+  // queryFn). Without the cast, the options type defaults prefetchInfiniteQuery generics to unknown,
+  // which conflicts with the generated queryFn expecting pageParam: number.
   lines.push(
-    `  void queryClient.prefetchInfiniteQuery({ ...${getInfiniteQueryOptionsName(endpoint)}(${endpointParams ? `{ ${endpointArgs} }` : ""}${hasAxiosRequestConfig ? `${endpointParams ? ", " : ""}${AXIOS_REQUEST_CONFIG_NAME}` : ""}), ...options });`,
+    `  void queryClient.prefetchInfiniteQuery({ ...${getInfiniteQueryOptionsName(endpoint)}(${optionsArgs}), ...(options as {}) });`,
   );
   lines.push("};");
   return lines.join("\n");
@@ -1007,7 +1012,7 @@ function renderMutation({
   );
   if (hasMutationEffects) {
     lines.push(
-      `  const { runMutationEffects } = useMutationEffects<typeof ${QUERY_MODULE_ENUM}.${tag}>({ currentModule: ${QUERIES_MODULE_NAME} });`,
+      `  const { runMutationEffects } = useMutationEffects<${QUERY_MODULE_ENUM}.${tag}>({ currentModule: ${QUERIES_MODULE_NAME} });`,
     );
   }
   lines.push("");

--- a/src/lib/react-query/useMutationEffects.ts
+++ b/src/lib/react-query/useMutationEffects.ts
@@ -9,7 +9,7 @@ export interface MutationEffectsOptions<TQueryModule extends QueryModule = Query
   invalidateCurrentModule?: boolean;
   crossTabInvalidation?: boolean;
   invalidationMap?: InvalidationMap<TQueryModule>;
-  invalidateModules?: TQueryModule[];
+  invalidateModules?: QueryModule[];
   invalidateKeys?: QueryKey[];
   preferUpdate?: boolean;
 }


### PR DESCRIPTION
## Summary

* Fix invalid `useMutationEffects<typeof QueryModule.*>` generation.
* Add explicit typing for `getNextPageParam`.
* Fix `prefetchInfiniteQuery` type inference when spreading optional options.
* Allow `invalidateModules` to invalidate queries across modules.
* Add regression tests covering the generated patterns.

## Details

### generateQueries.ts

* Generate `useMutationEffects<QueryModule.${tag}>` instead of `typeof QueryModule.${tag}`.
* Add an explicit response type to `getNextPageParam`.
* Prevent `prefetchInfiniteQuery` options from forcing `TPageParam` to `unknown`.

### useMutationEffects.ts

* Change `invalidateModules` from `TQueryModule[]` to `QueryModule[]`.

### Tests

* Add regression coverage for mutation effects and infinite query generation.
