### PR TITLE
fix: resolve resSchema namespace for shared response schemas

### DIFF
--- a/src/generators/generate/generateEndpoints.ts
+++ b/src/generators/generate/generateEndpoints.ts
@@ -102,7 +102,7 @@ export function generateEndpoints({ resolver, data, tag }: GenerateTypeParams) {
       `export const ${getEndpointName(endpoint)} = (${endpointParams}${hasAxiosRequestConfig ? `${AXIOS_REQUEST_CONFIG_NAME}?: ${AXIOS_REQUEST_CONFIG_TYPE}` : ""}) => {`,
     );
     lines.push(`    return ${APP_REST_CLIENT_NAME}.${endpoint.method}(`);
-    lines.push(`        { resSchema: ${getImportedZodSchemaName(resolver, endpoint.response, tag)} },`);
+    lines.push(`        { resSchema: ${getImportedZodSchemaName(resolver, endpoint.response)} },`);
     lines.push(`        \`${getEndpointPath(endpoint)}\`,`);
 
     if (endpointBody) {

--- a/src/generators/generateCodeFromOpenAPIDoc.test.ts
+++ b/src/generators/generateCodeFromOpenAPIDoc.test.ts
@@ -199,3 +199,114 @@ describe("generateCodeFromOpenAPIDoc", () => {
     expect(queries).not.toContain("scope: { id: `uploadAvatar:${userId}` }");
   });
 });
+
+describe("generateCodeFromOpenAPIDoc - shared response schema namespace", () => {
+  // StatusResponse is referenced by both rockets and pilots, so the resolver assigns it
+  // to the defaultTag ("Common"). The endpoint generator must not force the endpoint's
+  // own tag as the namespace prefix, or it would emit RocketsModels.StatusResponseSchema
+  // instead of CommonModels.StatusResponseSchema, leaving resSchema undefined at runtime.
+  const sharedSchemaDoc = {
+    openapi: "3.0.3",
+    info: { title: "Shared Schema Test", version: "1.0.0" },
+    paths: {
+      "/api/rockets/{id}/launch": {
+        post: {
+          tags: ["rockets"],
+          operationId: "launchRocket",
+          parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+          responses: {
+            "201": {
+              description: "Launched",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/StatusResponse" } } },
+            },
+          },
+        },
+      },
+      "/api/rockets/{id}": {
+        delete: {
+          tags: ["rockets"],
+          operationId: "deleteRocket",
+          parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+          responses: {
+            "200": {
+              description: "Deleted",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/StatusResponse" } } },
+            },
+          },
+        },
+      },
+      "/api/pilots/{id}": {
+        delete: {
+          tags: ["pilots"],
+          operationId: "deletePilot",
+          parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+          responses: {
+            "200": {
+              description: "Deleted",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/StatusResponse" } } },
+            },
+          },
+        },
+      },
+      "/api/rockets": {
+        get: {
+          tags: ["rockets"],
+          operationId: "getRockets",
+          responses: {
+            "200": {
+              description: "OK",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/RocketResponse" } } },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        StatusResponse: {
+          type: "object",
+          properties: {
+            status: { type: "string" },
+            message: { type: "string" },
+            code: { type: "string" },
+          },
+        },
+        RocketResponse: {
+          type: "object",
+          properties: {
+            id: { type: "string" },
+            name: { type: "string" },
+          },
+        },
+      },
+    },
+  } as unknown as OpenAPIV3.Document;
+
+  test("uses the owning namespace (CommonModels) for a response schema shared across tags", () => {
+    const files = generateCodeFromOpenAPIDoc(sharedSchemaDoc, DEFAULT_GENERATE_OPTIONS as GenerateOptions);
+    const rocketsApi = files.find(({ fileName }) => fileName === "output/rockets/rockets.api.ts")?.content;
+
+    expect(rocketsApi).toBeDefined();
+    expect(rocketsApi).toContain("CommonModels.StatusResponseSchema");
+    expect(rocketsApi).not.toContain("RocketsModels.StatusResponseSchema");
+  });
+
+  test("emits correct resSchema namespace for launch and delete endpoints", () => {
+    const files = generateCodeFromOpenAPIDoc(sharedSchemaDoc, DEFAULT_GENERATE_OPTIONS as GenerateOptions);
+    const rocketsApi = files.find(({ fileName }) => fileName === "output/rockets/rockets.api.ts")?.content;
+
+    expect(rocketsApi).toContain("resSchema: CommonModels.StatusResponseSchema");
+  });
+
+  test("uses the tag's own namespace for a response schema owned by a single tag", () => {
+    // RocketResponse is referenced only by the rockets tag, so getTagByZodSchemaName
+    // returns "rockets" and the generator must emit RocketsModels.RocketResponseSchema.
+    // This guards against a regression where auto-detection collapses all schemas into
+    // CommonModels regardless of ownership.
+    const files = generateCodeFromOpenAPIDoc(sharedSchemaDoc, DEFAULT_GENERATE_OPTIONS as GenerateOptions);
+    const rocketsApi = files.find(({ fileName }) => fileName === "output/rockets/rockets.api.ts")?.content;
+
+    expect(rocketsApi).toContain("RocketsModels.RocketResponseSchema");
+    expect(rocketsApi).not.toContain("CommonModels.RocketResponseSchema");
+  });
+});


### PR DESCRIPTION
When a response schema is shared across multiple tags, the resolver correctly assigns it to the default (`Common`) namespace. However, passing the endpoint tag as `namespaceTag` to `getImportedZodSchemaName` bypassed this resolution logic and forced the schema into the endpoint's namespace.

As a result, shared schemas such as `StatusResponseSchema` were emitted as:

* `RocketsModels.StatusResponseSchema`

instead of:

* `CommonModels.StatusResponseSchema`

This left `resSchema` undefined at runtime, causing successful responses to fail validation and surface as `openapi.sharedErrors.unknownError`.

This fixes the regression introduced in 3.0.0 by removing the `namespaceTag` override for response schemas and restoring automatic namespace resolution through `getTagByZodSchemaName`.

Also adds regression tests covering both resolution paths:

* Shared schema used across multiple tags → `CommonModels`
* Schema owned by a single tag → owning tag namespace (`RocketsModels`)