### PR TITLE
fix: exempt x-domain-error-domain schemas from inline enum validation

### DIFF
--- a/src/generators/core/zod/enumExtraction/updateExtractedEnumZodSchemaData.ts
+++ b/src/generators/core/zod/enumExtraction/updateExtractedEnumZodSchemaData.ts
@@ -21,6 +21,10 @@ export function updateExtractedEnumZodSchemaData({
   nameSegments?: string[];
   includeSelf?: boolean;
 } & SchemaInfo) {
+  if (!isReferenceObject(schema) && (schema as Record<string, unknown>)?.["x-domain-error-domain"]) {
+    return;
+  }
+
   if (includeSelf) {
     handleExtractedEnumZodSchemaDataUpdate({ schema, nameSegments, ...params });
   }

--- a/src/generators/generateCodeFromOpenAPIDoc.test.ts
+++ b/src/generators/generateCodeFromOpenAPIDoc.test.ts
@@ -2,6 +2,7 @@ import { OpenAPIV3 } from "openapi-types";
 import { describe, expect, test } from "vitest";
 
 import { DEFAULT_GENERATE_OPTIONS } from "./const/options.const";
+import { getDataFromOpenAPIDoc } from "./core/getDataFromOpenAPIDoc";
 import { generateCodeFromOpenAPIDoc } from "./generateCodeFromOpenAPIDoc";
 import { GenerateOptions } from "./types/options";
 
@@ -197,5 +198,95 @@ describe("generateCodeFromOpenAPIDoc", () => {
     expect(queries).toContain("mutationFn: async ({ userId, data, file, abortController, onUploadProgress }) => {");
     expect(queries).toContain("DocumentsApi.uploadAvatar(userId, data)");
     expect(queries).not.toContain("scope: { id: `uploadAvatar:${userId}` }");
+  });
+});
+
+describe("generateCodeFromOpenAPIDoc - inline enum validation for domain error schemas", () => {
+  // Doc with two endpoints:
+  //   - rockets launch: 400 response carries x-domain-error-domain with inline status/code enums
+  //   - widgets list:   200 response has a plain inline enum (no x-domain-error-domain)
+  const mixedDoc = {
+    openapi: "3.0.3",
+    info: { title: "Domain Error Enum Test", version: "1.0.0" },
+    paths: {
+      "/rockets/{id}/launch": {
+        post: {
+          tags: ["rockets"],
+          operationId: "RocketController_launch",
+          parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+          responses: {
+            "200": {
+              description: "Launched",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/StatusResponse" } } },
+            },
+            "400": {
+              description: "Could not launch",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    "x-domain-error-domain": "rocket",
+                    properties: {
+                      status: { type: "string", enum: ["error"] },
+                      code: { type: "number", enum: [1001] },
+                      message: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/widgets": {
+        get: {
+          tags: ["widgets"],
+          operationId: "WidgetController_list",
+          responses: {
+            "200": {
+              description: "OK",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      status: { type: "string", enum: ["active", "inactive"] },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        StatusResponse: { type: "object", properties: { status: { type: "string" } } },
+      },
+    },
+  } as unknown as OpenAPIV3.Document;
+
+  test("does not produce not-allowed-inline-enum errors for schemas with x-domain-error-domain", () => {
+    const { resolver } = getDataFromOpenAPIDoc(mixedDoc, DEFAULT_GENERATE_OPTIONS as GenerateOptions);
+    const inlineEnumErrors = resolver.validationErrors.filter((e) => e.type === "not-allowed-inline-enum");
+
+    expect(inlineEnumErrors.every((e) => !e.message.includes("RocketController_launch"))).toBe(true);
+  });
+
+  test("still produces not-allowed-inline-enum errors for normal schemas without x-domain-error-domain", () => {
+    const { resolver } = getDataFromOpenAPIDoc(mixedDoc, DEFAULT_GENERATE_OPTIONS as GenerateOptions);
+    const inlineEnumErrors = resolver.validationErrors.filter((e) => e.type === "not-allowed-inline-enum");
+
+    expect(inlineEnumErrors.some((e) => e.message.includes("WidgetController_list"))).toBe(true);
+  });
+
+  test("generates inline z.enum for domain error status field and does not emit StatusEnumSchema", () => {
+    const files = generateCodeFromOpenAPIDoc(mixedDoc, DEFAULT_GENERATE_OPTIONS as GenerateOptions);
+    const rocketsModels = files.find(({ fileName }) => fileName === "output/rockets/rockets.models.ts")?.content;
+
+    expect(rocketsModels).toBeDefined();
+    expect(rocketsModels).toContain('z.enum(["error"])');
+    expect(rocketsModels).not.toContain("StatusEnumSchema");
   });
 });


### PR DESCRIPTION
## Problem

Domain error response schemas generated by `@ApiDomainErrorResponse` intentionally contain inline enum properties:

```ts
status: { enum: ["error"] }
code: { enum: [<n>] }
```

These enums are used as a discriminator (`status`) and as the domain error identity (`code`).

The inline enum validator currently processes all response schemas, including domain error schemas marked with `x-domain-error-domain`. As a result, these intentional inline enums produce `not-allowed-inline-enum` validation errors, causing `openapi-codegen check` (and therefore `check:ci`) to fail.

## Fix

Skip inline enum extraction/validation for schemas marked with `x-domain-error-domain`.

This extension is emitted only by `@ApiDomainErrorResponse`, making the guard precise and scoped to domain error schemas.

Domain error code extraction remains unaffected, as it reads `code.enum` directly from the raw schema object and does not depend on the enum extraction pipeline.

## Side Effects

* `StatusEnumSchema` and `CodeEnumSchema` are no longer generated for domain error response schemas.
* `Launch400ErrorResponseSchema.status` is generated as `z.enum(["error"])` instead of referencing `StatusEnumSchema`.
* Runtime validation semantics remain unchanged.

## Tests

* Domain error schemas (`x-domain-error-domain` present) do not produce `not-allowed-inline-enum` validation errors.
* Normal inline enums continue to produce validation errors.
* Generated output uses inline `z.enum(["error"])` and does not reference removed enum schemas.