### PR TITLE
fix: correctly resolve optional  request body schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@povio/openapi-codegen-cli",
-  "version": "2.0.4",
+  "version": "2.0.8",
   "keywords": [
     "codegen",
     "openapi",

--- a/src/generators/core/endpoints/getEndpointBody.ts
+++ b/src/generators/core/endpoints/getEndpointBody.ts
@@ -6,7 +6,7 @@ import { resolveZodSchemaName } from "@/generators/core/zod/resolveZodSchemaName
 import { EndpointParameter } from "@/generators/types/endpoint";
 import { OperationObject } from "@/generators/types/openapi";
 import { isParamMediaTypeAllowed } from "@/generators/utils/openapi.utils";
-import { getBodyZodSchemaName, getZodSchemaOperationName } from "@/generators/utils/zod-schema.utils";
+import { getBodyZodSchemaName, getZodSchemaOperationName, isNamedZodSchema } from "@/generators/utils/zod-schema.utils";
 
 export function getEndpointBody({
   resolver,
@@ -56,12 +56,18 @@ export function getEndpointBody({
 
   const zodChain = getZodChain({ schema: schemaObject, meta: zodSchema.meta, options: resolver.options });
 
+  // For named (ref-based) schemas, store just the base name so namespace/import resolution
+  // can look it up correctly. The addOptional mechanism in the endpoint-param-parse template
+  // re-attaches .optional()/.nullish() at render time. For inline z.* schemas the chain must
+  // stay embedded because addOptional is skipped for non-named schemas.
+  const resolvedZodSchema = isNamedZodSchema(zodSchemaName) ? zodSchemaName : zodSchemaName + zodChain;
+
   return {
     endpointParameter: {
       name: BODY_PARAMETER_NAME,
       type: "Body",
       description: requestBodyObj.description,
-      zodSchema: zodSchemaName + zodChain,
+      zodSchema: resolvedZodSchema,
       bodyObject: requestBodyObj,
     },
     requestFormat: matchingMediaType,

--- a/src/generators/core/endpoints/getEndpointsFromOpenAPIDoc.test.ts
+++ b/src/generators/core/endpoints/getEndpointsFromOpenAPIDoc.test.ts
@@ -94,6 +94,62 @@ const generateOptions = {
 } as GenerateOptions;
 
 describe("getEndpointsFromOpenAPIDoc", () => {
+  test("optional $ref request body schema resolves base schema name without chain", () => {
+    const ScoringSessionEndRequest = {
+      required: ["score"],
+      type: "object",
+      properties: {
+        score: { type: "integer" },
+        notes: { type: "string" },
+      },
+    } as OpenAPIV3.SchemaObject;
+
+    const openApiDoc: OpenAPIV3.Document = {
+      ...baseDoc,
+      components: { schemas: { ScoringSessionEndRequest } },
+      paths: {
+        "/api/scoring-sessions/{sessionId}/end-session": {
+          post: {
+            tags: ["scoring"],
+            operationId: "endSession",
+            parameters: [
+              {
+                name: "sessionId",
+                in: "path",
+                required: true,
+                schema: { type: "string" },
+              },
+            ],
+            requestBody: {
+              required: false,
+              content: {
+                [JSON_APPLICATION_FORMAT]: {
+                  schema: { $ref: "#/components/schemas/ScoringSessionEndRequest" },
+                },
+              },
+            },
+            responses: {
+              "204": { description: "No content" },
+            },
+          },
+        },
+      },
+    };
+
+    const resolver = new SchemaResolver(openApiDoc, generateOptions);
+    const endpoints = getEndpointsFromOpenAPIDoc(resolver);
+
+    expect(endpoints).toHaveLength(1);
+    const bodyParam = endpoints[0].parameters.find((p) => p.type === "Body");
+    expect(bodyParam).toBeDefined();
+    // The zodSchema must be the bare component name — NOT "ScoringSessionEndRequest.optional()".
+    // Appending the chain before namespace/import resolution causes resolver.getTagByZodSchemaName
+    // to miss the lookup and fall back to defaultTag (CommonModels), producing wrong imports.
+    expect(bodyParam!.zodSchema).toBe("ScoringSessionEndRequest");
+    // The optional-ness is carried by bodyObject.required, not by a chain on zodSchema.
+    expect(bodyParam!.bodyObject?.required).toBe(false);
+  });
+
   test("getEndpointsFromOpenAPIDocPaths /store/order", () => {
     const openApiDoc: OpenAPIV3.Document = {
       ...baseDoc,


### PR DESCRIPTION
## Summary

- Fix optional `$ref` request body schema resolution
- Preserve base schema names during namespace resolution
- Add regression test covering optional referenced request bodies

## Testing

- pnpm test
- pnpm tsc --noEmit

## Notes

While validating this fix in monorepo-template, I identified a separate compatibility issue affecting some ESM-first environments (Node v24 + pnpm + `"type": "module"`).

This issue is unrelated to the optional `$ref` request body schema bug addressed in this PR and appears to be tied to the build/runtime setup used in the main branch.

No changes related to that issue are included in this PR to keep the scope focused on the reported bug.

It's also worth noting that `feat/3.0.0` already uses a different build pipeline (`tsdown`) and outputs an ESM (`.mjs`) binary by default, so this specific compatibility issue is not expected to affect the 3.0.0 release line.
