### PR TITLE
fix: correctly resolve optional  request body schemas

### DIFF
--- a/src/generators/core/endpoints/getEndpointsFromOpenAPIDoc.test.ts
+++ b/src/generators/core/endpoints/getEndpointsFromOpenAPIDoc.test.ts
@@ -1979,4 +1979,47 @@ describe("getEndpointsFromOpenAPIDoc", () => {
       ]),
     );
   });
+
+  test("optional $ref request body schema resolves base schema name without chain", () => {
+    const ScoringSessionEndRequest = {
+      required: ["score"],
+      type: "object",
+      properties: {
+        score: { type: "integer" },
+        notes: { type: "string" },
+      },
+    } as OpenAPIV3.SchemaObject;
+
+    const openApiDoc: OpenAPIV3.Document = {
+      ...baseDoc,
+      components: { schemas: { ScoringSessionEndRequest } },
+      paths: {
+        "/api/scoring-sessions/{sessionId}/end-session": {
+          post: {
+            tags: ["scoring"],
+            operationId: "endSession",
+            parameters: [{ name: "sessionId", in: "path", required: true, schema: { type: "string" } }],
+            requestBody: {
+              required: false,
+              content: {
+                [JSON_APPLICATION_FORMAT]: {
+                  schema: { $ref: "#/components/schemas/ScoringSessionEndRequest" },
+                },
+              },
+            },
+            responses: { "204": { description: "No content" } },
+          },
+        },
+      },
+    };
+
+    const resolver = new SchemaResolver(openApiDoc, generateOptions);
+    const endpoints = getEndpointsFromOpenAPIDoc(resolver);
+
+    expect(endpoints).toHaveLength(1);
+    const bodyParam = endpoints[0].parameters.find((p) => p.type === "Body");
+    expect(bodyParam).toBeDefined();
+    expect(bodyParam!.zodSchema).toBe("ScoringSessionEndRequest");
+    expect(bodyParam!.bodyObject?.required).toBe(false);
+  });
 });

--- a/src/generators/core/endpoints/resolveEndpointZodSchema.ts
+++ b/src/generators/core/endpoints/resolveEndpointZodSchema.ts
@@ -6,6 +6,7 @@ import { getZodSchema } from "@/generators/core/zod/getZodSchema";
 import { resolveZodSchemaName } from "@/generators/core/zod/resolveZodSchemaName";
 import { ZodSchemaMetaData } from "@/generators/core/zod/ZodSchema.class";
 import { isReferenceObject } from "@/generators/utils/openapi-schema.utils";
+import { isNamedZodSchema } from "@/generators/utils/zod-schema.utils";
 
 type EndpointZodSchemaCache = {
   byObject: WeakMap<object, Map<string, string>>;
@@ -85,7 +86,10 @@ export function resolveEndpointZodSchema({
         resolver,
         tag,
       })
-    : `${resolveZodSchemaName({ schema: schemaObject, zodSchema, fallbackName, resolver, tag })}${zodChain}`;
+    : (() => {
+        const name = resolveZodSchemaName({ schema: schemaObject, zodSchema, fallbackName, resolver, tag });
+        return isNamedZodSchema(name) ? name : name + zodChain;
+      })();
 
   entries.set(metaKey, resolved);
   return resolved;


### PR DESCRIPTION
## Summary

* Fix optional `$ref` request body schema resolution
* Preserve base schema names for referenced request body schemas during namespace resolution
* Add regression test covering optional referenced request bodies

## Root Cause

Optional referenced request body schemas were being stored with their Zod modifier chain (e.g. `ScoringSessionEndRequestSchema.optional()`) before namespace/tag resolution.

As a result, namespace resolution attempted to look up the chained schema name instead of the base schema name, causing referenced schemas to fall back to the default namespace.

## Fix

* Preserve the base schema name for referenced request body schemas
* Apply optional/nullish modifiers during rendering instead of during schema resolution
* Keep existing behavior unchanged for inline schemas

## Testing

* Added regression test for optional `$ref` request body schemas
* All tests passing
* TypeScript check passing