### PR TITLE
feat: support string codes in domain error generation

### DIFF
--- a/src/generators/core/endpoints/getEndpointsFromOpenAPIDoc.ts
+++ b/src/generators/core/endpoints/getEndpointsFromOpenAPIDoc.ts
@@ -182,8 +182,10 @@ export function getEndpointsFromOpenAPIDoc(resolver: SchemaResolver) {
             const codeEnum = (rawSchema?.properties as Record<string, unknown> | undefined)?.code;
             const codeEnumArr = (codeEnum as Record<string, unknown> | undefined)?.enum;
             const domainCode =
-              Array.isArray(codeEnumArr) && codeEnumArr.length === 1 && typeof codeEnumArr[0] === "number"
-                ? (codeEnumArr[0] as number)
+              Array.isArray(codeEnumArr) &&
+              codeEnumArr.length === 1 &&
+              (typeof codeEnumArr[0] === "number" || typeof codeEnumArr[0] === "string")
+                ? (codeEnumArr[0] as number | string)
                 : undefined;
 
             endpoint.errors.push({

--- a/src/generators/generate/generateDomainErrors.ts
+++ b/src/generators/generate/generateDomainErrors.ts
@@ -7,7 +7,7 @@ function domainToPascalCase(domain: string): string {
 }
 
 interface DomainErrorDef {
-  code: number;
+  code: number | string;
   name?: string;
   description?: string;
 }
@@ -18,7 +18,7 @@ export function generateDomainErrors({
   resolver: SchemaResolver;
   data: GenerateData;
 }): string | undefined {
-  const byDomain = new Map<string, Map<number, DomainErrorDef>>();
+  const byDomain = new Map<string, Map<number | string, DomainErrorDef>>();
 
   for (const { endpoints } of data.values()) {
     for (const endpoint of endpoints) {
@@ -44,13 +44,25 @@ export function generateDomainErrors({
 
   for (const [domain, codes] of [...byDomain.entries()].sort(([a], [b]) => a.localeCompare(b))) {
     const pascalName = domainToPascalCase(domain);
-    const sortedCodes = [...codes.values()].sort((a, b) => a.code - b.code);
+    const sortedCodes = [...codes.values()].sort((a, b) => {
+      if (typeof a.code === "number" && typeof b.code === "number") return a.code - b.code;
+      const sa = String(a.code);
+      const sb = String(b.code);
+      return sa < sb ? -1 : sa > sb ? 1 : 0;
+    });
 
     const entries = sortedCodes
       .map(({ code, name, description }) => {
         const comment = description ? `  /** ${description} */\n  ` : "  ";
-        const key = name ?? `ERROR_${code}`;
-        return `${comment}${key}: ${code}`;
+        const key = name ?? (typeof code === "string" ? code : `ERROR_${code}`);
+        if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key)) {
+          throw new Error(
+            `Domain error code "${code}" produces an invalid identifier "${key}". ` +
+              `Use the 'name' field on @ApiDomainErrorResponse to provide a valid identifier.`,
+          );
+        }
+        const value = typeof code === "string" ? `"${code}"` : String(code);
+        return `${comment}${key}: ${value}`;
       })
       .join(",\n");
 

--- a/src/generators/generate/generateDomainErrors.ts
+++ b/src/generators/generate/generateDomainErrors.ts
@@ -6,6 +6,8 @@ function domainToPascalCase(domain: string): string {
   return domain.split(/[-_]/).map(capitalize).join("");
 }
 
+const VALID_IDENTIFIER = /^[a-zA-Z_$][a-zA-Z0-9_$]*$/;
+
 interface DomainErrorDef {
   code: number | string;
   name?: string;
@@ -55,7 +57,7 @@ export function generateDomainErrors({
       .map(({ code, name, description }) => {
         const comment = description ? `  /** ${description} */\n  ` : "  ";
         const key = name ?? (typeof code === "string" ? code : `ERROR_${code}`);
-        if (!/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(key)) {
+        if (!VALID_IDENTIFIER.test(key)) {
           throw new Error(
             `Domain error code "${code}" produces an invalid identifier "${key}". ` +
               `Use the 'name' field on @ApiDomainErrorResponse to provide a valid identifier.`,

--- a/src/generators/types/endpoint.ts
+++ b/src/generators/types/endpoint.ts
@@ -14,7 +14,7 @@ export interface EndpointParameter {
 
 export interface DomainErrorInfo {
   domain: string;
-  code: number;
+  code: number | string;
   name?: string;
 }
 


### PR DESCRIPTION
## Summary

- Extend domain error `code` support from `number` to `number | string` across extraction, types, and code generation
- Generate string error codes as quoted values while preserving existing numeric code generation
- Update domain error sorting to preserve numeric ordering for numeric codes and use deterministic lexical ordering for string or mixed code sets
- Validate generated error keys and throw a descriptive error when a code cannot be converted into a valid identifier, directing users to provide a valid `name`

## Test plan

- [x] Numeric error codes generate the same output as before (no regression)
- [x] String error codes (e.g. `"USER_BLOCKED"`) generate quoted values and use the code as the generated key
- [x] Invalid string codes (e.g. `"not-found"`) fail generation with an error message instructing users to provide a valid `name`
- [x] Mixed numeric and string codes within the same domain are generated in a deterministic order