### PR TITLE
fix: preserve blob config on endpoints with 400 domain error responses

### DIFF
--- a/src/generators/core/endpoints/getEndpointsFromOpenAPIDoc.ts
+++ b/src/generators/core/endpoints/getEndpointsFromOpenAPIDoc.ts
@@ -133,7 +133,14 @@ export function getEndpointsFromOpenAPIDoc(resolver: SchemaResolver) {
 
         let schema: OpenAPIV3.ReferenceObject | OpenAPIV3.SchemaObject | undefined;
         if (matchingMediaType) {
-          endpoint.responseFormat = matchingMediaType;
+          const statusNum = Number(statusCode);
+          // Only let success responses (2xx) or "default" (when nothing is set yet) determine the
+          // response format used for the Accept header. Error responses (4xx/5xx) must not
+          // overwrite the success content-type — doing so would strip rawResponse/blob config
+          // from blob-download endpoints that also declare domain-error responses.
+          if (isMainResponseStatus(statusNum) || (statusCode === "default" && !endpoint.responseFormat)) {
+            endpoint.responseFormat = matchingMediaType;
+          }
           schema = responseObj.content?.[matchingMediaType]?.schema;
         } else if (statusCode === "200") {
           resolver.validationErrors.push(

--- a/src/generators/generate/generateEndpoints.ts
+++ b/src/generators/generate/generateEndpoints.ts
@@ -204,7 +204,8 @@ function renderEndpointConfig(
 ) {
   const endpointConfig = getEndpointConfig(endpoint);
   const hasAxiosRequestConfig = resolver.options.axiosRequestConfig;
-  if (Object.keys(endpointConfig).length === 0) {
+  const needsBlobConfig = endpoint.mediaDownload || endpoint.response === "z.instanceof(Blob)";
+  if (Object.keys(endpointConfig).length === 0 && !needsBlobConfig) {
     return hasAxiosRequestConfig ? AXIOS_REQUEST_CONFIG_NAME : "";
   }
 

--- a/src/generators/generate/generateQueries.ts
+++ b/src/generators/generate/generateQueries.ts
@@ -713,7 +713,8 @@ function getSortingPresenceChain(resolver: SchemaResolver, param: EndpointParame
 function renderInlineEndpointConfig(resolver: SchemaResolver, endpoint: Endpoint, modelNamespaceTag?: string) {
   const endpointConfig = getEndpointConfig(endpoint);
   const hasAxiosRequestConfig = resolver.options.axiosRequestConfig;
-  if (Object.keys(endpointConfig).length === 0) {
+  const needsBlobConfig = endpoint.mediaDownload || endpoint.response === "z.instanceof(Blob)";
+  if (Object.keys(endpointConfig).length === 0 && !needsBlobConfig) {
     return hasAxiosRequestConfig ? AXIOS_REQUEST_CONFIG_NAME : "";
   }
 

--- a/src/generators/generateCodeFromOpenAPIDoc.test.ts
+++ b/src/generators/generateCodeFromOpenAPIDoc.test.ts
@@ -576,3 +576,169 @@ describe("generateCodeFromOpenAPIDoc - shared response schema namespace", () => 
     expect(rocketsApi).not.toContain("CommonModels.RocketResponseSchema");
   });
 });
+
+describe("generateCodeFromOpenAPIDoc - blob download with domain errors", () => {
+  const domainErrorSchema = {
+    type: "object",
+    "x-domain-error-domain": "cmr",
+    "x-domain-error-name": "CmrNotFound",
+    properties: {
+      code: { type: "number", enum: [4001] },
+      message: { type: "string" },
+    },
+  } as unknown as OpenAPIV3.SchemaObject;
+
+  const blobDoc = {
+    openapi: "3.0.3",
+    info: { title: "Blob Download Test", version: "1.0.0" },
+    paths: {
+      "/offices/{officeId}/cmrs/{cmrId}/preview": {
+        get: {
+          tags: ["Documents"],
+          operationId: "previewCmr",
+          "x-media-download": true,
+          parameters: [
+            { name: "officeId", in: "path", required: true, schema: { type: "string" } },
+            { name: "cmrId", in: "path", required: true, schema: { type: "string" } },
+          ],
+          responses: {
+            "200": {
+              description: "PDF preview",
+              content: { "application/pdf": { schema: { type: "string", format: "binary" } } },
+            },
+            "400": {
+              description: "Domain error",
+              content: { "application/json": { schema: domainErrorSchema } },
+            },
+            "401": { description: "Unauthorized" },
+          },
+        } as unknown as OpenAPIV3.OperationObject,
+      },
+      "/offices/{officeId}/cmrs/{cmrId}/preview-no-error": {
+        get: {
+          tags: ["Documents"],
+          operationId: "previewCmrNoError",
+          "x-media-download": true,
+          parameters: [
+            { name: "officeId", in: "path", required: true, schema: { type: "string" } },
+            { name: "cmrId", in: "path", required: true, schema: { type: "string" } },
+          ],
+          responses: {
+            "200": {
+              description: "PDF preview",
+              content: { "application/pdf": { schema: { type: "string", format: "binary" } } },
+            },
+            "401": { description: "Unauthorized" },
+          },
+        } as unknown as OpenAPIV3.OperationObject,
+      },
+      "/offices/{officeId}/cmrs/{cmrId}/download": {
+        get: {
+          tags: ["Documents"],
+          operationId: "downloadCmr",
+          "x-media-download": true,
+          parameters: [
+            { name: "officeId", in: "path", required: true, schema: { type: "string" } },
+            { name: "cmrId", in: "path", required: true, schema: { type: "string" } },
+            { name: "format", in: "query", required: false, schema: { type: "string" } },
+          ],
+          responses: {
+            "200": {
+              description: "PDF download",
+              content: { "application/pdf": { schema: { type: "string", format: "binary" } } },
+            },
+            "400": {
+              description: "Domain error",
+              content: { "application/json": { schema: domainErrorSchema } },
+            },
+            "401": { description: "Unauthorized" },
+          },
+        } as unknown as OpenAPIV3.OperationObject,
+      },
+      "/files/eml": {
+        post: {
+          tags: ["Documents"],
+          operationId: "getFilesEml",
+          "x-media-download": true,
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: { type: "object", properties: { ids: { type: "array", items: { type: "string" } } } },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description: "EML file",
+              content: { "application/octet-stream": { schema: { type: "string", format: "binary" } } },
+            },
+            "400": {
+              description: "Domain error",
+              content: { "application/json": { schema: domainErrorSchema } },
+            },
+            "401": { description: "Unauthorized" },
+          },
+        } as unknown as OpenAPIV3.OperationObject,
+      },
+      "/offices/{officeId}/items": {
+        get: {
+          tags: ["Documents"],
+          operationId: "listItems",
+          parameters: [
+            { name: "officeId", in: "path", required: true, schema: { type: "string" } },
+          ],
+          responses: {
+            "200": {
+              description: "OK",
+              content: { "application/json": { schema: { type: "array", items: { type: "string" } } } },
+            },
+            "400": {
+              description: "Domain error",
+              content: { "application/json": { schema: domainErrorSchema } },
+            },
+          },
+        } as unknown as OpenAPIV3.OperationObject,
+      },
+    },
+    components: { schemas: {} },
+  } as unknown as OpenAPIV3.Document;
+
+  const files = generateCodeFromOpenAPIDoc(blobDoc, DEFAULT_GENERATE_OPTIONS as GenerateOptions);
+  const api = files.find(({ fileName }) => fileName === "output/documents/documents.api.ts")?.content;
+
+  test("api file is generated", () => {
+    expect(api).toBeDefined();
+  });
+
+  test("blob + domain error 400, path params only: emits responseType blob, rawResponse, and Accept header", () => {
+    expect(api).toContain('responseType: "blob"');
+    expect(api).toContain("rawResponse: true");
+    expect(api).toContain("'Accept': 'application/pdf'");
+  });
+
+  test("blob + domain error 400, path params only: previewCmr endpoint has full blob config", () => {
+    expect(api).toMatch(/previewCmr[\s\S]*?responseType: "blob"[\s\S]*?rawResponse: true/);
+  });
+
+  test("blob without domain error (regression): previewCmrNoError also emits blob config", () => {
+    expect(api).toMatch(/previewCmrNoError[\s\S]*?responseType: "blob"[\s\S]*?rawResponse: true/);
+  });
+
+  test("blob + domain error + query param: downloadCmr emits blob config with params block", () => {
+    expect(api).toMatch(/downloadCmr[\s\S]*?params[\s\S]*?responseType: "blob"[\s\S]*?rawResponse: true/);
+  });
+
+  test("blob + domain error, POST body only: getFilesEml emits blob config with octet-stream Accept", () => {
+    expect(api).toMatch(/getFilesEml[\s\S]*?responseType: "blob"[\s\S]*?rawResponse: true/);
+    expect(api).toContain("'Accept': 'application/octet-stream'");
+  });
+
+  test("non-blob JSON endpoint with 400 error: no rawResponse or responseType blob", () => {
+    const listItemsSection = api?.slice(api.indexOf("listItems"));
+    const nextFnStart = listItemsSection?.indexOf("export const", 1);
+    const listItemsCode = nextFnStart ? listItemsSection?.slice(0, nextFnStart) : listItemsSection;
+    expect(listItemsCode).not.toContain("rawResponse");
+    expect(listItemsCode).not.toContain('responseType: "blob"');
+  });
+});

--- a/src/generators/utils/generate/generate.endpoints.utils.ts
+++ b/src/generators/utils/generate/generate.endpoints.utils.ts
@@ -33,7 +33,8 @@ export const getEndpointBody = (endpoint: Endpoint) => endpoint.parameters.find(
 export const hasEndpointConfig = (endpoint: Endpoint, resolver: SchemaResolver) => {
   const endpointConfig = getEndpointConfig(endpoint);
   const hasAxiosRequestConfig = resolver.options.axiosRequestConfig;
-  return Object.keys(endpointConfig).length > 0 || hasAxiosRequestConfig;
+  const needsBlobConfig = endpoint.mediaDownload || endpoint.response === "z.instanceof(Blob)";
+  return Object.keys(endpointConfig).length > 0 || hasAxiosRequestConfig || needsBlobConfig;
 };
 
 export const getEndpointPath = (endpoint: Endpoint) => endpoint.path.replace(/:([a-zA-Z0-9_]+)/g, "${$1}");


### PR DESCRIPTION
## Summary

Fixes a codegen issue where blob/media-download endpoints lost `rawResponse: true`, `responseType: "blob"`, and the custom `Accept` header after adding `400` domain error responses.

## Problem

After adding `@ApiDomainErrorResponse` annotations to blob/media-download endpoints, regeneration started producing invalid FE API clients.

Endpoints like CMR preview and EML export should return `AxiosResponse<Blob>`, but the generated config was missing the blob/raw response setup, which caused TypeScript errors in consumers.

Two issues caused this:

1. `endpoint.responseFormat` was overwritten by error responses
   The OpenAPI response parsing loop updated `endpoint.responseFormat` for every response with a body, including `400 application/json` domain error responses.
   As a result, a successful `200 application/pdf` response could be overwritten by the error response format.

2. Blob config was skipped when the endpoint config was otherwise empty
   `responseType: "blob"` and `rawResponse: true` were emitted only inside the endpoint config block. For path-param-only endpoints, once the custom `Accept` header disappeared, the config block was considered empty and skipped entirely.

## Changes

* Only set `endpoint.responseFormat` from `2xx` responses, using `default` only as a fallback.
* Prevent blob/media-download endpoints from being skipped by the endpoint config renderers.
* Update `hasEndpointConfig` so blob endpoints are treated as having config.
* Add tests for blob endpoints with domain errors, blob regressions, query-param cases, POST blob responses, and non-blob JSON endpoints.

## Acceptance

* Blob endpoints with `400 application/json` domain errors generate `responseType: "blob"`, `rawResponse: true`, and the correct `Accept` header.
* Blob endpoints without documented error responses still work.
* Non-blob JSON endpoints with domain errors are unaffected.