### PR TITLE
fix: align Metro codegen startup flow with Metro lifecycle

### DIFF
--- a/src/metro/openapi-codegen.plugin.test.ts
+++ b/src/metro/openapi-codegen.plugin.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, test, vi } from "vitest";
 
 import { runGenerate } from "@/generators/run/generate.runner";
 
+import type { MetroConfig } from "./openapi-codegen.plugin";
 import { withOpenApiCodegen } from "./openapi-codegen.plugin";
 
 vi.mock("@/generators/run/generate.runner", () => ({
@@ -18,54 +19,313 @@ describe("Metro openapi-codegen plugin", () => {
     runGenerateMock.mockResolvedValue(undefined as never);
   });
 
-  test("waits for generation before delegating to Metro transform options", async () => {
-    const root = path.resolve("/app");
-    const transformOptions = {
-      transform: {
-        experimentalImportSupport: false,
-        inlineRequires: true,
-      },
-    };
-    const getTransformOptions = vi.fn((..._args: unknown[]) => transformOptions);
-    let resolveGenerate: () => void = () => undefined;
-    const generatePromise = new Promise<void>((resolve) => {
-      resolveGenerate = resolve;
+  describe("middleware", () => {
+    test("waits for startup generation before delegating to the wrapped middleware", async () => {
+      const root = path.resolve("/app");
+      let resolveGenerate: () => void = () => undefined;
+      const generatePromise = new Promise<void>((resolve) => {
+        resolveGenerate = resolve;
+      });
+
+      runGenerateMock.mockImplementationOnce(async () => {
+        await generatePromise;
+        return undefined as never;
+      });
+
+      const config: MetroConfig = withOpenApiCodegen(
+        { projectRoot: root } as MetroConfig,
+        { input: "./openapi.yaml", output: "./src/data" },
+        { watchOpenApiInput: false },
+      );
+
+      const innerMiddleware = vi.fn((_req, _res, next: (e?: unknown) => void) => next());
+      const wrappedMiddleware = config.server?.enhanceMiddleware?.(innerMiddleware, {});
+      if (!wrappedMiddleware) throw new Error("Expected enhanceMiddleware to return a middleware");
+
+      const req = {} as never;
+      const res = {} as never;
+      const next = vi.fn();
+
+      const requestDone = wrappedMiddleware(req, res, next);
+
+      await Promise.resolve();
+      expect(innerMiddleware).not.toHaveBeenCalled();
+
+      resolveGenerate();
+      await requestDone;
+
+      expect(innerMiddleware).toHaveBeenCalledWith(req, res, next);
+      expect(runGenerateMock).toHaveBeenCalledTimes(1);
     });
 
-    runGenerateMock.mockImplementationOnce(async () => {
-      await generatePromise;
-      return undefined as never;
+    test("does not re-run generation on subsequent requests after startup succeeds", async () => {
+      const root = path.resolve("/app");
+      const config: MetroConfig = withOpenApiCodegen(
+        { projectRoot: root } as MetroConfig,
+        { input: "./openapi.yaml", output: "./src/data" },
+        { watchOpenApiInput: false },
+      );
+
+      const innerMiddleware = vi.fn((_req, _res, next: (e?: unknown) => void) => next());
+      const wrappedMiddleware = config.server?.enhanceMiddleware?.(innerMiddleware, {});
+      if (!wrappedMiddleware) throw new Error("Expected enhanceMiddleware to return a middleware");
+
+      const req = {} as never;
+      const res = {} as never;
+      const next = vi.fn();
+
+      await wrappedMiddleware(req, res, next);
+      await wrappedMiddleware(req, res, next);
+      await wrappedMiddleware(req, res, next);
+
+      expect(runGenerateMock).toHaveBeenCalledTimes(1);
     });
 
-    const config = withOpenApiCodegen(
-      {
-        projectRoot: root,
-        transformer: { getTransformOptions },
-      },
-      { input: "./openapi.yaml", output: "./src/data" },
-      { watchOpenApiInput: false },
-    );
-    const wrappedGetTransformOptions = config.transformer?.getTransformOptions;
-    if (!wrappedGetTransformOptions) {
-      throw new Error("Expected Metro getTransformOptions wrapper");
-    }
+    test("retries failed startup generation on the next request", async () => {
+      const root = path.resolve("/app");
+      const firstError = new Error("generation failed");
+      runGenerateMock.mockRejectedValueOnce(firstError);
 
-    const result = wrappedGetTransformOptions("entry");
+      const config: MetroConfig = withOpenApiCodegen(
+        { projectRoot: root } as MetroConfig,
+        { input: "./openapi.yaml", output: "./src/data" },
+        { watchOpenApiInput: false },
+      );
 
-    await Promise.resolve();
-    expect(getTransformOptions).not.toHaveBeenCalled();
+      const innerMiddleware = vi.fn((_req, _res, next: (e?: unknown) => void) => next());
+      const wrappedMiddleware = config.server?.enhanceMiddleware?.(innerMiddleware, {});
+      if (!wrappedMiddleware) throw new Error("Expected enhanceMiddleware to return a middleware");
 
-    resolveGenerate();
-    await expect(Promise.resolve(result)).resolves.toBe(transformOptions);
+      const req = {} as never;
+      const res = {} as never;
+      const next = vi.fn();
 
-    expect(getTransformOptions).toHaveBeenCalledWith("entry");
-    expect(runGenerateMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        fileConfig: expect.objectContaining({
-          input: path.join(root, "openapi.yaml"),
-          output: path.join(root, "src/data"),
+      // First request: generation fails, next(error) is called
+      await wrappedMiddleware(req, res, next);
+      expect(next).toHaveBeenCalledWith(firstError);
+      expect(innerMiddleware).not.toHaveBeenCalled();
+
+      next.mockReset();
+
+      // Second request: generation succeeds, middleware proceeds
+      await wrappedMiddleware(req, res, next);
+      expect(next).toHaveBeenCalledWith();
+      expect(innerMiddleware).toHaveBeenCalledWith(req, res, next);
+
+      expect(runGenerateMock).toHaveBeenCalledTimes(2);
+    });
+
+    test("concurrent requests during startup share one generation run", async () => {
+      const root = path.resolve("/app");
+      let resolveGenerate: () => void = () => undefined;
+      const generatePromise = new Promise<void>((resolve) => {
+        resolveGenerate = resolve;
+      });
+
+      runGenerateMock.mockImplementationOnce(async () => {
+        await generatePromise;
+        return undefined as never;
+      });
+
+      const config: MetroConfig = withOpenApiCodegen(
+        { projectRoot: root } as MetroConfig,
+        { input: "./openapi.yaml", output: "./src/data" },
+        { watchOpenApiInput: false },
+      );
+
+      const innerMiddleware = vi.fn((_req, _res, next: (e?: unknown) => void) => next());
+      const wrappedMiddleware = config.server?.enhanceMiddleware?.(innerMiddleware, {});
+      if (!wrappedMiddleware) throw new Error("Expected enhanceMiddleware to return a middleware");
+
+      const req = {} as never;
+      const res = {} as never;
+      const next = vi.fn();
+
+      const r1 = wrappedMiddleware(req, res, next);
+      const r2 = wrappedMiddleware(req, res, next);
+      const r3 = wrappedMiddleware(req, res, next);
+
+      resolveGenerate();
+      await Promise.all([r1, r2, r3]);
+
+      expect(runGenerateMock).toHaveBeenCalledTimes(1);
+      expect(innerMiddleware).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("getTransformOptions", () => {
+    test("waits for startup generation before delegating to the original getTransformOptions", async () => {
+      const root = path.resolve("/app");
+      const transformOptions = {
+        transform: { experimentalImportSupport: false, inlineRequires: true },
+      };
+      const getTransformOptions = vi.fn(() => transformOptions);
+      let resolveGenerate: () => void = () => undefined;
+      const generatePromise = new Promise<void>((resolve) => {
+        resolveGenerate = resolve;
+      });
+
+      runGenerateMock.mockImplementationOnce(async () => {
+        await generatePromise;
+        return undefined as never;
+      });
+
+      const config: MetroConfig = withOpenApiCodegen(
+        { projectRoot: root, transformer: { getTransformOptions } } as MetroConfig,
+        { input: "./openapi.yaml", output: "./src/data" },
+        { watchOpenApiInput: false },
+      );
+
+      const wrappedGetTransformOptions = config.transformer?.getTransformOptions;
+      if (!wrappedGetTransformOptions) throw new Error("Expected transformer.getTransformOptions wrapper");
+
+      const result = wrappedGetTransformOptions("entry");
+
+      await Promise.resolve();
+      expect(getTransformOptions).not.toHaveBeenCalled();
+
+      resolveGenerate();
+      await expect(Promise.resolve(result)).resolves.toBe(transformOptions);
+      expect(getTransformOptions).toHaveBeenCalledWith("entry");
+    });
+
+    test("retries failed startup generation on the next getTransformOptions call", async () => {
+      const root = path.resolve("/app");
+      const firstError = new Error("generation failed");
+      runGenerateMock.mockRejectedValueOnce(firstError);
+
+      const transformOptions = { transform: { experimentalImportSupport: false, inlineRequires: false } };
+      const getTransformOptions = vi.fn(() => transformOptions);
+
+      const config: MetroConfig = withOpenApiCodegen(
+        { projectRoot: root, transformer: { getTransformOptions } } as MetroConfig,
+        { input: "./openapi.yaml", output: "./src/data" },
+        { watchOpenApiInput: false },
+      );
+
+      const wrappedGetTransformOptions = config.transformer?.getTransformOptions;
+      if (!wrappedGetTransformOptions) throw new Error("Expected transformer.getTransformOptions wrapper");
+
+      await expect(wrappedGetTransformOptions("entry")).rejects.toThrow(firstError);
+      expect(getTransformOptions).not.toHaveBeenCalled();
+
+      await expect(wrappedGetTransformOptions("entry")).resolves.toBe(transformOptions);
+      expect(getTransformOptions).toHaveBeenCalledWith("entry");
+      expect(runGenerateMock).toHaveBeenCalledTimes(2);
+    });
+
+    test("returns undefined when there is no original getTransformOptions", async () => {
+      const root = path.resolve("/app");
+      const config: MetroConfig = withOpenApiCodegen(
+        { projectRoot: root } as MetroConfig,
+        { input: "./openapi.yaml", output: "./src/data" },
+        { watchOpenApiInput: false },
+      );
+
+      const wrappedGetTransformOptions = config.transformer?.getTransformOptions;
+      if (!wrappedGetTransformOptions) throw new Error("Expected transformer.getTransformOptions wrapper");
+
+      const result = await wrappedGetTransformOptions("entry");
+      expect(result).toBeUndefined();
+    });
+
+    test("does not re-run generation on subsequent getTransformOptions calls after startup succeeds", async () => {
+      const root = path.resolve("/app");
+      const config: MetroConfig = withOpenApiCodegen(
+        { projectRoot: root } as MetroConfig,
+        { input: "./openapi.yaml", output: "./src/data" },
+        { watchOpenApiInput: false },
+      );
+
+      const wrappedGetTransformOptions = config.transformer?.getTransformOptions;
+      if (!wrappedGetTransformOptions) throw new Error("Expected transformer.getTransformOptions wrapper");
+
+      await wrappedGetTransformOptions("entry1");
+      await wrappedGetTransformOptions("entry2");
+      await wrappedGetTransformOptions("entry3");
+
+      expect(runGenerateMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("config wrapping", () => {
+    test("preserves existing Metro config fields", () => {
+      const root = path.resolve("/app");
+      const config = withOpenApiCodegen(
+        {
+          projectRoot: root,
+          watchFolders: ["/shared"],
+          resolver: { sourceExts: ["ts", "tsx"] },
+        },
+        { input: "./openapi.yaml", output: "./src/data" },
+        { watchOpenApiInput: false },
+      );
+
+      expect(config.watchFolders).toEqual(["/shared"]);
+      expect(config.resolver).toEqual({ sourceExts: ["ts", "tsx"] });
+    });
+
+    test("chains existing enhanceMiddleware with the codegen wrapper", async () => {
+      const root = path.resolve("/app");
+      const originalEnhanced = vi.fn((_req: unknown, _res: unknown, next: (e?: unknown) => void) => next());
+      const originalEnhanceMiddleware = vi.fn((_m: unknown, _s: unknown) => originalEnhanced);
+
+      const config: MetroConfig = withOpenApiCodegen(
+        { projectRoot: root, server: { enhanceMiddleware: originalEnhanceMiddleware } } as MetroConfig,
+        { input: "./openapi.yaml", output: "./src/data" },
+        { watchOpenApiInput: false },
+      );
+
+      const innerMiddleware = vi.fn();
+      const wrappedMiddleware = config.server?.enhanceMiddleware?.(innerMiddleware as never, {});
+      if (!wrappedMiddleware) throw new Error("Expected enhanceMiddleware to return a middleware");
+
+      await wrappedMiddleware({} as never, {} as never, vi.fn());
+
+      expect(originalEnhanceMiddleware).toHaveBeenCalledWith(innerMiddleware, {});
+      expect(originalEnhanced).toHaveBeenCalled();
+      expect(innerMiddleware).not.toHaveBeenCalled();
+    });
+
+    test("accepts a Promise<MetroConfig> and resolves it before wrapping", async () => {
+      const root = path.resolve("/app");
+      const result = await withOpenApiCodegen(
+        Promise.resolve({ projectRoot: root, watchFolders: ["/extra"] } as MetroConfig),
+        { input: "./openapi.yaml", output: "./src/data" },
+        { watchOpenApiInput: false },
+      );
+
+      expect(result.watchFolders).toEqual(["/extra"]);
+      expect(result.transformer?.getTransformOptions).toBeDefined();
+    });
+
+    test("does not mutate the input MetroConfig object", () => {
+      const root = path.resolve("/app");
+      const original = { projectRoot: root };
+
+      withOpenApiCodegen(original, { input: "./openapi.yaml", output: "./src/data" }, { watchOpenApiInput: false });
+
+      expect(original).toEqual({ projectRoot: root });
+    });
+
+    test("normalizes paths relative to the resolved root", async () => {
+      const root = path.resolve("/app");
+      const config: MetroConfig = withOpenApiCodegen(
+        { projectRoot: root } as MetroConfig,
+        { input: "./openapi.yaml", output: "./src/data" },
+        { watchOpenApiInput: false },
+      );
+
+      await config.transformer?.getTransformOptions?.("entry");
+
+      expect(runGenerateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fileConfig: expect.objectContaining({
+            input: path.join(root, "openapi.yaml"),
+            output: path.join(root, "src/data"),
+          }),
         }),
-      }),
-    );
+      );
+    });
   });
 });

--- a/src/metro/openapi-codegen.plugin.ts
+++ b/src/metro/openapi-codegen.plugin.ts
@@ -34,13 +34,6 @@ export type MetroConfig = {
   [key: string]: unknown;
 };
 
-const DEFAULT_TRANSFORM_OPTIONS = {
-  transform: {
-    experimentalImportSupport: false,
-    inlineRequires: false,
-  },
-};
-
 export function withOpenApiCodegen<TMetroConfig extends MetroConfig>(
   metroConfig: Promise<TMetroConfig>,
   codegenConfig: OpenApiCodegenMetroConfig,
@@ -72,32 +65,33 @@ function withResolvedOpenApiCodegen<TMetroConfig extends MetroConfig>(
   const codegen = createOpenApiCodegenRunner(codegenConfig);
   const originalEnhanceMiddleware = metroConfig.server?.enhanceMiddleware;
   const originalGetTransformOptions = metroConfig.transformer?.getTransformOptions;
-  let startupRequested = false;
-  let pendingGenerate: Promise<void> | undefined;
+
+  let startupSucceeded = false;
+  let inflightGenerate: Promise<void> | undefined;
   let inputWatcher: fs.FSWatcher | undefined;
 
-  const enqueueAndTrack = () => {
-    const run = codegen.enqueueGenerate(root);
-    const tracked = run.finally(() => {
-      if (pendingGenerate === tracked) {
-        pendingGenerate = undefined;
-      }
-    });
-
-    pendingGenerate = tracked;
-    return run;
-  };
-
-  const ensureStartupGenerate = () => {
-    if (startupRequested) {
-      return pendingGenerate ?? Promise.resolve();
+  const requestStartupGenerate = (): Promise<void> => {
+    if (startupSucceeded) {
+      return Promise.resolve();
     }
 
-    startupRequested = true;
-    return enqueueAndTrack().catch((error: unknown) => {
-      startupRequested = false;
-      throw error;
-    });
+    if (inflightGenerate) {
+      return inflightGenerate;
+    }
+
+    const attempt = codegen.enqueueGenerate(root).then(
+      () => {
+        startupSucceeded = true;
+        inflightGenerate = undefined;
+      },
+      (error: unknown) => {
+        inflightGenerate = undefined;
+        throw error;
+      },
+    );
+
+    inflightGenerate = attempt;
+    return attempt;
   };
 
   const ensureInputWatcher = () => {
@@ -112,7 +106,8 @@ function withResolvedOpenApiCodegen<TMetroConfig extends MetroConfig>(
 
     try {
       inputWatcher = fs.watch(inputPath, { persistent: false }, () => {
-        enqueueAndTrack().catch(reportGenerateError);
+        startupSucceeded = false;
+        requestStartupGenerate().catch(reportGenerateError);
       });
       inputWatcher.on("error", reportWatcherError);
     } catch (error) {
@@ -120,14 +115,11 @@ function withResolvedOpenApiCodegen<TMetroConfig extends MetroConfig>(
     }
   };
 
-  void ensureStartupGenerate().catch(reportGenerateError);
-
   const wrappedConfig: MetroConfig = {
     ...metroConfig,
     server: {
       ...metroConfig.server,
       enhanceMiddleware(middleware, server) {
-        void ensureStartupGenerate().catch(reportGenerateError);
         ensureInputWatcher();
 
         const enhancedMiddleware = originalEnhanceMiddleware
@@ -136,8 +128,8 @@ function withResolvedOpenApiCodegen<TMetroConfig extends MetroConfig>(
 
         return async (request, response, next) => {
           try {
-            await ensureStartupGenerate();
-            return await Promise.resolve(enhancedMiddleware(request, response, next));
+            await requestStartupGenerate();
+            return await (enhancedMiddleware(request, response, next) as Promise<unknown>);
           } catch (error) {
             next(error);
           }
@@ -147,8 +139,8 @@ function withResolvedOpenApiCodegen<TMetroConfig extends MetroConfig>(
     transformer: {
       ...metroConfig.transformer,
       async getTransformOptions(...args) {
-        await ensureStartupGenerate();
-        return originalGetTransformOptions ? originalGetTransformOptions(...args) : DEFAULT_TRANSFORM_OPTIONS;
+        await requestStartupGenerate();
+        return originalGetTransformOptions ? originalGetTransformOptions(...args) : undefined;
       },
     },
   };


### PR DESCRIPTION
## Summary

Improves the Metro OpenAPI codegen integration by making generation lifecycle-driven rather than running during Metro config evaluation.

### Changes

* Remove startup generation during `withOpenApiCodegen()` construction
* Ensure codegen is awaited through Metro lifecycle hooks before middleware and transform processing continue
* Simplify startup generation state tracking by separating successful startup generation from in-flight generation
* Preserve Metro defaults by removing the hardcoded `getTransformOptions` fallback
* Improve retry behavior after failed generation attempts
* Expand Metro integration test coverage around startup, retries, concurrent requests, and config wrapping

### Context

The goal is to make the Metro integration behave more like the existing Vite integration, where codegen is triggered as part of the build/startup lifecycle rather than during configuration evaluation.

This keeps the existing `withOpenApiCodegen()` API unchanged and continues to reuse the shared OpenAPI codegen runner.
