### PR TITLE
fix: resolve builder configs generation issues

### DIFF
--- a/src/generators/generate/generateConfigs.test.ts
+++ b/src/generators/generate/generateConfigs.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, it } from "vitest";
+import { OpenAPIV3 } from "openapi-types";
+
+import { DEFAULT_GENERATE_OPTIONS } from "@/generators/const/options.const";
+import { generateCodeFromOpenAPIDoc } from "@/generators/generateCodeFromOpenAPIDoc";
+
+const openApiDoc = {
+  openapi: "3.0.0",
+  info: { title: "Builder Configs Test", version: "1.0.0" },
+  paths: {
+    "/items": {
+      get: {
+        tags: ["items"],
+        operationId: "list",
+        parameters: [
+          { name: "page", in: "query", schema: { type: "integer" } },
+          { name: "limit", in: "query", schema: { type: "integer" } },
+        ],
+        responses: {
+          "200": {
+            description: "OK",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/ItemsPage" } } },
+          },
+        },
+      },
+      post: {
+        tags: ["items"],
+        operationId: "createItem",
+        requestBody: {
+          required: true,
+          content: { "application/json": { schema: { $ref: "#/components/schemas/Item" } } },
+        },
+        responses: {
+          "201": {
+            description: "Created",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/Item" } } },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Item: {
+        type: "object",
+        properties: { id: { type: "string" } },
+        required: ["id"],
+      },
+      ItemsPage: {
+        type: "object",
+        properties: {
+          items: { type: "array", items: { $ref: "#/components/schemas/Item" } },
+          page: { type: "integer" },
+          totalItems: { type: "integer" },
+          limit: { type: "integer" },
+        },
+        required: ["items", "limit"],
+      },
+    },
+  },
+} as OpenAPIV3.Document;
+
+// Same as openApiDoc, but createItem has a no-conditions ACL ability so checkAcl must be
+// called without an argument - tests checking acl:false reuse openApiDoc instead, since
+// endpoint.acl metadata is extracted regardless of the acl/checkAcl options.
+const openApiDocWithAcl = {
+  ...openApiDoc,
+  paths: {
+    ...openApiDoc.paths,
+    "/items": {
+      ...openApiDoc.paths["/items"],
+      post: {
+        ...openApiDoc.paths["/items"]!.post,
+        "x-acl": [{ action: "create", subject: "Item" }],
+      },
+    },
+  },
+} as OpenAPIV3.Document;
+
+describe("generateConfigs builderConfigs", () => {
+  it("imports the sibling <Domain>Queries namespace referenced by usePaginate", () => {
+    const files = generateCodeFromOpenAPIDoc(openApiDoc, {
+      ...DEFAULT_GENERATE_OPTIONS,
+      output: "test-output",
+      builderConfigs: true,
+      mutationEffects: false,
+      acl: false,
+      checkAcl: false,
+    });
+
+    const configsFile = files.find((file) => file.fileName.endsWith("/items/items.configs.ts"));
+
+    expect(configsFile?.content).toContain('import { ItemsQueries } from "./items.queries";');
+    expect(configsFile?.content).toContain("paginated: ItemsQueries.useList");
+  });
+
+  it("references the QueryModule const enum directly (no typeof) and types options with MutationEffectsOptions", () => {
+    const files = generateCodeFromOpenAPIDoc(openApiDoc, {
+      ...DEFAULT_GENERATE_OPTIONS,
+      output: "test-output",
+      builderConfigs: true,
+      mutationEffects: true,
+      acl: false,
+      checkAcl: false,
+    });
+
+    const configsFile = files.find((file) => file.fileName.endsWith("/items/items.configs.ts"));
+
+    expect(configsFile?.content).toContain("useMutationEffects<QueryModule.items>");
+    expect(configsFile?.content).not.toContain("useMutationEffects<typeof QueryModule.items>");
+    expect(configsFile?.content).toContain("& MutationEffectsOptions)");
+  });
+
+  it("does not emit an unused OpenApiWorkspaceContext import when workspaceContext is empty", () => {
+    const files = generateCodeFromOpenAPIDoc(openApiDoc, {
+      ...DEFAULT_GENERATE_OPTIONS,
+      output: "test-output",
+      builderConfigs: true,
+      mutationEffects: true,
+      acl: false,
+      checkAcl: false,
+      workspaceContext: [],
+    });
+
+    const configsFile = files.find((file) => file.fileName.endsWith("/items/items.configs.ts"));
+
+    expect(configsFile?.content).not.toContain("OpenApiWorkspaceContext");
+  });
+
+  it("calls runMutationEffects with the mutation result, variables and options, matching renderMutation", () => {
+    const files = generateCodeFromOpenAPIDoc(openApiDoc, {
+      ...DEFAULT_GENERATE_OPTIONS,
+      output: "test-output",
+      builderConfigs: true,
+      mutationEffects: true,
+      acl: false,
+      checkAcl: false,
+    });
+
+    const configsFile = files.find((file) => file.fileName.endsWith("/items/items.configs.ts"));
+
+    expect(configsFile?.content).toContain("await runMutationEffects(resData, variables, options);");
+    expect(configsFile?.content).not.toContain("await runMutationEffects();");
+    // the wrapping onSuccess must come after ...options, or a caller-provided options.onSuccess
+    // would silently disable mutation effects by overriding it.
+    expect(configsFile?.content).toMatch(/\.\.\.options,[\s\S]*onSuccess: async \(resData, variables/);
+  });
+
+  it("does not pass an argument to checkAcl when the ability has no conditions", () => {
+    const files = generateCodeFromOpenAPIDoc(openApiDocWithAcl, {
+      ...DEFAULT_GENERATE_OPTIONS,
+      output: "test-output",
+      builderConfigs: true,
+      acl: true,
+      checkAcl: true,
+    });
+
+    const configsFile = files.find((file) => file.fileName.endsWith("/items/items.configs.ts"));
+
+    expect(configsFile?.content).toContain("checkAcl(ItemsAcl.canUseCreate());");
+  });
+});
+
+describe("generateConfigs builderConfigs ACL conditions", () => {
+  // createRocket's ability has an officeId condition, so checkAcl must be called with the
+  // matching object - renderMutationContent must reuse the shared renderAclCheckCall helper
+  // instead of unconditionally forwarding every destructured mutation arg.
+  const officeScopedDoc = {
+    openapi: "3.0.0",
+    info: { title: "Builder Configs ACL Conditions Test", version: "1.0.0" },
+    paths: {
+      "/offices/{officeId}/rockets": {
+        get: {
+          tags: ["rockets"],
+          operationId: "list",
+          parameters: [
+            { name: "officeId", in: "path", required: true, schema: { type: "string" } },
+            { name: "page", in: "query", schema: { type: "integer" } },
+            { name: "limit", in: "query", schema: { type: "integer" } },
+          ],
+          responses: {
+            "200": {
+              description: "OK",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/RocketsPage" } } },
+            },
+          },
+        },
+        post: {
+          tags: ["rockets"],
+          operationId: "createRocket",
+          "x-acl": [{ action: "create", subject: "Rocket", conditions: { officeId: "$params.officeId" } }],
+          parameters: [{ name: "officeId", in: "path", required: true, schema: { type: "string" } }],
+          requestBody: {
+            required: true,
+            content: { "application/json": { schema: { $ref: "#/components/schemas/Rocket" } } },
+          },
+          responses: {
+            "201": {
+              description: "Created",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/Rocket" } } },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Rocket: {
+          type: "object",
+          properties: { id: { type: "string" }, name: { type: "string" } },
+          required: ["id"],
+        },
+        RocketsPage: {
+          type: "object",
+          properties: {
+            items: { type: "array", items: { $ref: "#/components/schemas/Rocket" } },
+            page: { type: "integer" },
+            totalItems: { type: "integer" },
+            limit: { type: "integer" },
+          },
+          required: ["items"],
+        },
+      },
+    },
+  } as unknown as OpenAPIV3.Document;
+
+  it("passes the matching conditions object to checkAcl when the ability has conditions", () => {
+    const files = generateCodeFromOpenAPIDoc(officeScopedDoc, {
+      ...DEFAULT_GENERATE_OPTIONS,
+      output: "test-output",
+      builderConfigs: true,
+      acl: true,
+      checkAcl: true,
+    });
+
+    const configsFile = files.find((file) => file.fileName.endsWith("/rockets/rockets.configs.ts"));
+
+    expect(configsFile?.content).toContain("checkAcl(RocketsAcl.canUseCreate({ officeId }");
+  });
+});
+
+describe("generateConfigs builderConfigs media upload", () => {
+  // upload's endpoint function only accepts the DTO - the file itself is uploaded separately
+  // to uploadInstructions.url, exactly like renderMutation does for *.queries.ts. Passing file
+  // as a second argument to the endpoint call is a type error: "expected 1 argument, got 2".
+  const mediaUploadDoc = {
+    openapi: "3.0.0",
+    info: { title: "Builder Configs Media Upload Test", version: "1.0.0" },
+    paths: {
+      "/media": {
+        get: {
+          tags: ["media"],
+          operationId: "list",
+          parameters: [
+            { name: "page", in: "query", schema: { type: "integer" } },
+            { name: "limit", in: "query", schema: { type: "integer" } },
+          ],
+          responses: {
+            "200": {
+              description: "OK",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/MediaPage" } } },
+            },
+          },
+        },
+        post: {
+          tags: ["media"],
+          operationId: "upload",
+          "x-media-upload": true,
+          requestBody: {
+            required: true,
+            content: { "application/json": { schema: { $ref: "#/components/schemas/UploadDto" } } },
+          },
+          responses: {
+            "201": {
+              description: "Created",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/UploadInstructions" } } },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        UploadDto: { type: "object", properties: { method: { type: "string" } } },
+        UploadInstructions: { type: "object", properties: { url: { type: "string" } } },
+        Media: { type: "object", properties: { id: { type: "string" } }, required: ["id"] },
+        MediaPage: {
+          type: "object",
+          properties: {
+            items: { type: "array", items: { $ref: "#/components/schemas/Media" } },
+            page: { type: "integer" },
+            totalItems: { type: "integer" },
+            limit: { type: "integer" },
+          },
+          required: ["items"],
+        },
+      },
+    },
+  } as unknown as OpenAPIV3.Document;
+
+  it("calls the endpoint with only the DTO and uploads the file separately to uploadInstructions.url", () => {
+    const files = generateCodeFromOpenAPIDoc(mediaUploadDoc, {
+      ...DEFAULT_GENERATE_OPTIONS,
+      output: "test-output",
+      builderConfigs: true,
+      acl: false,
+      checkAcl: false,
+    });
+
+    const configsFile = files.find((file) => file.fileName.endsWith("/media/media.configs.ts"));
+
+    expect(configsFile?.content).toContain("const uploadInstructions = await MediaApi.upload(data);");
+    expect(configsFile?.content).not.toContain("MediaApi.upload(data, file)");
+    expect(configsFile?.content).toContain("await axios[method](uploadInstructions.url, dataToSend,");
+    expect(configsFile?.content).toContain("return uploadInstructions;");
+  });
+
+  it("imports axios as the default import for the upload call", () => {
+    const files = generateCodeFromOpenAPIDoc(mediaUploadDoc, {
+      ...DEFAULT_GENERATE_OPTIONS,
+      output: "test-output",
+      builderConfigs: true,
+      acl: false,
+      checkAcl: false,
+    });
+
+    const configsFile = files.find((file) => file.fileName.endsWith("/media/media.configs.ts"));
+
+    expect(configsFile?.content).toContain('import axios, { type AxiosRequestConfig } from "axios";');
+  });
+});

--- a/src/generators/generate/generateConfigs.ts
+++ b/src/generators/generate/generateConfigs.ts
@@ -1,4 +1,5 @@
 import { ACL_CHECK_HOOK } from "@/generators/const/acl.const";
+import { AXIOS_DEFAULT_IMPORT_NAME, AXIOS_REQUEST_CONFIG_TYPE } from "@/generators/const/endpoints.const";
 import { PACKAGE_IMPORT_PATH, ACL_PACKAGE_IMPORT_PATH } from "@/generators/const/package.const";
 import {
   MUTATION_EFFECTS,
@@ -13,17 +14,18 @@ import { GenerateType, GenerateTypeParams, Import } from "@/generators/types/gen
 import {
   getImportedEndpointName,
   mapEndpointParamsToFunctionParams,
+  renderMediaUploadMutationBody,
 } from "@/generators/utils/generate/generate.endpoints.utils";
 import { getEndpointsImports } from "@/generators/utils/generate/generate.imports.utils";
 import { getBuilderConfigs } from "@/generators/utils/generate/generate.configs.utils";
+import { renderAclCheckCall } from "@/generators/utils/generate/generate.acl.utils";
 import { getNamespaceName } from "@/generators/utils/namespace.utils";
 import { getQueryModulesImportPath, getQueryTypesImportPath } from "@/generators/utils/generate/generate.utils";
 import { getEndpointTag } from "@/generators/utils/tag.utils";
-import { capitalize, snakeToCamel } from "@/generators/utils/string.utils";
 import { QUERY_HOOKS } from "@/generators/const/queries.const";
 
 export function generateConfigs(generateTypeParams: GenerateTypeParams) {
-  const { configs, hasZodImport, modelsImports, aclImports } = getBuilderConfigs(generateTypeParams);
+  const { configs, hasZodImport, modelsImports, queriesImports, aclImports } = getBuilderConfigs(generateTypeParams);
   if (configs.length === 0) {
     return;
   }
@@ -43,8 +45,15 @@ export function generateConfigs(generateTypeParams: GenerateTypeParams) {
   const hasAclCheck = resolver.options.checkAcl && endpoints.some((e) => e.acl);
   const hasMutationEffects = resolver.options.mutationEffects && hasMutation;
   const hasMutationDefaultOnError = resolver.options.mutationDefaultOnError && hasMutation;
-  const hasWorkspaceContext =
-    resolver.options.workspaceContext && endpoints.some((e) => resolver.options.workspaceContext); // Simplified check
+  const hasAxiosRequestConfig = resolver.options.axiosRequestConfig;
+  const hasAxiosDefaultImport = endpoints.some((e) => e.mediaUpload);
+  const hasAxiosImport = hasAxiosRequestConfig || hasAxiosDefaultImport;
+  const axiosImport: Import = {
+    defaultImport: hasAxiosDefaultImport ? AXIOS_DEFAULT_IMPORT_NAME : undefined,
+    bindings: [],
+    typeBindings: hasAxiosImport ? [AXIOS_REQUEST_CONFIG_TYPE] : [],
+    from: "axios",
+  };
 
   const endpointsImports = getEndpointsImports({
     tag,
@@ -79,11 +88,6 @@ export function generateConfigs(generateTypeParams: GenerateTypeParams) {
     from: ACL_PACKAGE_IMPORT_PATH,
   };
 
-  const workspaceContextImport: Import = {
-    bindings: ["OpenApiWorkspaceContext"],
-    from: PACKAGE_IMPORT_PATH,
-  };
-
   const hasDynamicInputsImport = configs.some(
     (config) => config.readAll.filters || config.create?.inputDefs || config.update?.inputDefs, // || config.bulkDelete?.inputDefs,
   );
@@ -99,6 +103,9 @@ export function generateConfigs(generateTypeParams: GenerateTypeParams) {
   };
 
   const lines: string[] = [];
+  if (hasAxiosImport) {
+    lines.push(renderImport(axiosImport));
+  }
   if (hasZodImport) {
     lines.push(renderImport(ZOD_IMPORT));
   }
@@ -110,6 +117,9 @@ export function generateConfigs(generateTypeParams: GenerateTypeParams) {
   }
   for (const modelsImport of modelsImports) {
     lines.push(renderImport(modelsImport));
+  }
+  for (const queriesImport of queriesImports) {
+    lines.push(renderImport(queriesImport));
   }
   // Endpoints are needed for inlined mutations
   for (const endpointsImport of endpointsImports) {
@@ -123,9 +133,8 @@ export function generateConfigs(generateTypeParams: GenerateTypeParams) {
       lines.push(renderImport(queryModulesImport));
       lines.push(renderImport(mutationEffectsImport));
     }
-    lines.push(renderImport(aclCheckImport));
-    if (hasWorkspaceContext) {
-      lines.push(renderImport(workspaceContextImport));
+    if (hasAclCheck) {
+      lines.push(renderImport(aclCheckImport));
     }
   }
 
@@ -212,6 +221,11 @@ function renderMutationContent(resolver: any, endpoint: Endpoint, tag: string) {
   const endpointParamsStr = endpointParams.map((p) => `${p.name}${p.required ? "" : "?"}: ${p.type}`).join("; ");
 
   const destructuredMutationArgs = endpointParams.map((p) => p.name).join(", ");
+  // The file itself isn't part of the endpoint function's call signature - it's uploaded
+  // separately to the URL the endpoint call returns. See renderMediaUploadMutationBody.
+  const resolvedEndpointArgs = mapEndpointParamsToFunctionParams(resolver, endpoint, { modelNamespaceTag: endpointTag })
+    .map((p) => p.name)
+    .join(", ");
   const endpointFunction = getImportedEndpointName(endpoint, resolver.options);
 
   const mutationVariablesType = endpoint.mediaUpload
@@ -220,7 +234,7 @@ function renderMutationContent(resolver: any, endpoint: Endpoint, tag: string) {
 
   const lines: string[] = [];
   lines.push(
-    `(options?: AppMutationOptions<typeof ${endpointFunction}, ${mutationVariablesType}>${hasAxiosRequestConfig ? `, config?: AxiosRequestConfig` : ""}) => {`,
+    `(options?: AppMutationOptions<typeof ${endpointFunction}, ${mutationVariablesType}>${hasMutationEffects ? ` & ${MUTATION_EFFECTS.optionsType}` : ""}${hasAxiosRequestConfig ? `, config?: ${AXIOS_REQUEST_CONFIG_TYPE}` : ""}) => {`,
   );
   if (hasMutationDefaultOnError) {
     lines.push("  const queryConfig = OpenApiQueryConfig.useConfig();");
@@ -228,10 +242,12 @@ function renderMutationContent(resolver: any, endpoint: Endpoint, tag: string) {
 
   if (hasMutationEffects) {
     lines.push(
-      `  const { runMutationEffects } = useMutationEffects<typeof ${QUERY_MODULE_ENUM}.${endpointTag}>({ currentModule: ${QUERY_MODULE_ENUM}.${tag} });`,
+      `  const { runMutationEffects } = useMutationEffects<${QUERY_MODULE_ENUM}.${endpointTag}>({ currentModule: ${QUERY_MODULE_ENUM}.${tag} });`,
     );
   }
-  lines.push(`  const { checkAcl } = ${ACL_CHECK_HOOK}();`);
+  if (hasAclCheck) {
+    lines.push(`  const { checkAcl } = ${ACL_CHECK_HOOK}();`);
+  }
   lines.push("");
   lines.push(`  return ${QUERY_HOOKS.mutation}({`);
 
@@ -239,25 +255,31 @@ function renderMutationContent(resolver: any, endpoint: Endpoint, tag: string) {
     ? `{ ${destructuredMutationArgs}${endpoint.mediaUpload ? `${destructuredMutationArgs ? ", " : ""}abortController, onUploadProgress` : ""} }`
     : "";
 
-  lines.push(`    mutationFn: (${mutationFnArg}) => {`);
+  lines.push(`    mutationFn: ${endpoint.mediaUpload ? "async " : ""}(${mutationFnArg}) => {`);
   if (hasAclCheck) {
+    lines.push(renderAclCheckCall(resolver, endpoint, undefined, "      "));
+  }
+  if (endpoint.mediaUpload) {
     lines.push(
-      `      checkAcl(${getNamespaceName({ type: GenerateType.Acl, tag: endpointTag, options: resolver.options })}.canUse${capitalize(snakeToCamel(endpoint.operationName))}({ ${destructuredMutationArgs} }));`,
+      ...renderMediaUploadMutationBody({ resolver, endpointFunction, resolvedEndpointArgs }).map(
+        (line) => `      ${line}`,
+      ),
+    );
+  } else {
+    lines.push(
+      `      return ${endpointFunction}(${destructuredMutationArgs}${hasAxiosRequestConfig ? `${destructuredMutationArgs ? ", " : ""}config` : ""});`,
     );
   }
-  lines.push(
-    `      return ${endpointFunction}(${destructuredMutationArgs}${hasAxiosRequestConfig ? `${destructuredMutationArgs ? ", " : ""}config` : ""});`,
-  );
   lines.push("    },");
-  if (hasMutationEffects) {
-    lines.push("    onSuccess: async (...args) => {");
-    lines.push("      await runMutationEffects();");
-    lines.push("      await options?.onSuccess?.(...args);");
-    lines.push("    },");
-  }
   lines.push("    ...options,");
   if (hasMutationDefaultOnError) {
     lines.push("    onError: options?.onError ?? queryConfig.onError,");
+  }
+  if (hasMutationEffects) {
+    lines.push("    onSuccess: async (resData, variables, onMutateResult, context) => {");
+    lines.push("      await runMutationEffects(resData, variables, options);");
+    lines.push("      options?.onSuccess?.(resData, variables, onMutateResult, context);");
+    lines.push("    },");
   }
   lines.push("  });");
   lines.push("}");

--- a/src/generators/generate/generateQueries.ts
+++ b/src/generators/generate/generateQueries.ts
@@ -25,8 +25,7 @@ import { getUniqueArray } from "@/generators/utils/array.utils";
 import {
   getAbilityConditionsTypes,
   getAbilityFunctionName,
-  getImportedAbilityFunctionName,
-  hasAbilityConditions,
+  renderAclCheckCall,
 } from "@/generators/utils/generate/generate.acl.utils";
 import {
   getEndpointBody,
@@ -36,6 +35,7 @@ import {
   hasEndpointConfig,
   getImportedEndpointName,
   mapEndpointParamsToFunctionParams,
+  renderMediaUploadMutationBody,
   requiresBody,
 } from "@/generators/utils/generate/generate.endpoints.utils";
 import { getSchemaDescriptions } from "@/generators/utils/generate/generate.openapi.utils";
@@ -498,29 +498,6 @@ function renderWorkspaceParamResolutions({
     ...renderWorkspaceContextDestructure({ replacements, paramTypes, indent }),
     ...renderWorkspaceParamCoalescing({ replacements, indent }),
   ];
-}
-
-function renderAclCheckCall(
-  resolver: SchemaResolver,
-  endpoint: Endpoint,
-  replacements?: Record<string, string>,
-  indent = "",
-) {
-  const checkParams = getAbilityConditionsTypes(endpoint)?.map((condition) =>
-    invalidVariableNameCharactersToCamel(condition.name),
-  );
-  const paramNames = new Set(endpoint.parameters.map((param) => invalidVariableNameCharactersToCamel(param.name)));
-  const hasAllCheckParams = checkParams?.every((param) => paramNames.has(param));
-  const args =
-    hasAbilityConditions(endpoint) && hasAllCheckParams
-      ? `{ ${(checkParams ?? [])
-          .map((param) => {
-            const resolvedParam = replacements?.[param] ?? param;
-            return resolvedParam === param ? param : `${param}: ${resolvedParam}`;
-          })
-          .join(", ")} } `
-      : "";
-  return `${indent}checkAcl(${getImportedAbilityFunctionName(endpoint, resolver.options)}(${args}));`;
 }
 
 function addAsteriskAfterNewLine(str: string) {
@@ -1070,35 +1047,10 @@ function renderMutation({
   }
   if (endpoint.mediaUpload) {
     lines.push(
-      `      const uploadInstructions = await ${endpointFunction}(${resolvedEndpointArgs}${hasAxiosRequestConfig ? `${resolvedEndpointArgs ? ", " : ""}${AXIOS_REQUEST_CONFIG_NAME}` : ""});`,
+      ...renderMediaUploadMutationBody({ resolver, endpointFunction, resolvedEndpointArgs }).map(
+        (line) => `      ${line}`,
+      ),
     );
-    lines.push("      ");
-    lines.push("      if (file && uploadInstructions.url) {");
-    lines.push('        const method = (data?.method?.toLowerCase() ?? "put") as "put" | "post";');
-    lines.push("        let dataToSend: File | FormData = file;");
-    lines.push('        if (method === "post") {');
-    lines.push("          dataToSend = new FormData();");
-    lines.push("          if (uploadInstructions.fields) {");
-    lines.push("            for (const [key, value] of uploadInstructions.fields) {");
-    lines.push("              dataToSend.append(key, value);");
-    lines.push("            }");
-    lines.push("          }");
-    lines.push('          dataToSend.append("file", file);');
-    lines.push("        }");
-    lines.push("        await axios[method](uploadInstructions.url, dataToSend, {");
-    lines.push("          headers: {");
-    lines.push('            "Content-Type": file.type,');
-    lines.push("          },");
-    lines.push("          signal: abortController?.signal,");
-    lines.push("          onUploadProgress: onUploadProgress");
-    lines.push(
-      "          ? (progressEvent) => onUploadProgress({ loaded: progressEvent.loaded, total: progressEvent.total ?? 0 })",
-    );
-    lines.push("          : undefined,");
-    lines.push("        });");
-    lines.push("      }");
-    lines.push("      ");
-    lines.push("      return uploadInstructions;");
   } else {
     lines.push(
       `      ${hasMutationFnBody ? "return " : ""}${endpointFunction}(${resolvedEndpointArgs}${hasAxiosRequestConfig ? `${resolvedEndpointArgs ? ", " : ""}${AXIOS_REQUEST_CONFIG_NAME}` : ""})`,

--- a/src/generators/generateCodeFromOpenAPIDoc.test.ts
+++ b/src/generators/generateCodeFromOpenAPIDoc.test.ts
@@ -742,3 +742,117 @@ describe("generateCodeFromOpenAPIDoc - blob download with domain errors", () => 
     expect(listItemsCode).not.toContain('responseType: "blob"');
   });
 });
+
+describe("generateCodeFromOpenAPIDoc - shared parameter schema namespace", () => {
+  // TokenFiltersDto is used as a query parameter by both pushNotificationAdmin and
+  // pushNotification, so the resolver assigns it to the defaultTag ("Common"). The endpoint
+  // parameter renderer (mapEndpointParamsToFunctionParams / renderEndpointParamParse) must not
+  // force the endpoint's own tag as the namespace prefix, or it would emit
+  // PushNotificationAdminModels.TokenFiltersDto instead of CommonModels.TokenFiltersDto.
+  const sharedParamSchemaDoc = {
+    openapi: "3.0.3",
+    info: { title: "Shared Parameter Schema Test", version: "1.0.0" },
+    paths: {
+      "/push-notifications/admin/tokens": {
+        get: {
+          tags: ["pushNotificationAdmin"],
+          operationId: "listAdminTokens",
+          parameters: [
+            { name: "filter", in: "query", schema: { $ref: "#/components/schemas/TokenFiltersDto" } },
+            { name: "page", in: "query", schema: { type: "integer" } },
+            { name: "limit", in: "query", schema: { type: "integer" } },
+          ],
+          responses: {
+            "200": {
+              description: "OK",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/TokensPage" } } },
+            },
+          },
+        },
+        post: {
+          tags: ["pushNotificationAdmin"],
+          operationId: "createAdminToken",
+          requestBody: {
+            required: true,
+            content: { "application/json": { schema: { $ref: "#/components/schemas/TokenFiltersDto" } } },
+          },
+          responses: {
+            "201": {
+              description: "Created",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/Token" } } },
+            },
+          },
+        },
+      },
+      "/push-notifications/tokens": {
+        get: {
+          tags: ["pushNotification"],
+          operationId: "listTokens",
+          parameters: [{ name: "filter", in: "query", schema: { $ref: "#/components/schemas/TokenFiltersDto" } }],
+          responses: {
+            "200": {
+              description: "OK",
+              content: { "application/json": { schema: { $ref: "#/components/schemas/TokensPage" } } },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        TokenFiltersDto: {
+          type: "object",
+          properties: { deviceId: { type: "string" } },
+        },
+        Token: {
+          type: "object",
+          properties: { id: { type: "string" } },
+          required: ["id"],
+        },
+        TokensPage: {
+          type: "object",
+          properties: {
+            items: { type: "array", items: { $ref: "#/components/schemas/Token" } },
+            page: { type: "integer" },
+            totalItems: { type: "integer" },
+            limit: { type: "integer" },
+          },
+          required: ["items"],
+        },
+      },
+    },
+  } as unknown as OpenAPIV3.Document;
+
+  const files = generateCodeFromOpenAPIDoc(sharedParamSchemaDoc, {
+    ...(DEFAULT_GENERATE_OPTIONS as GenerateOptions),
+    builderConfigs: true,
+    acl: false,
+    checkAcl: false,
+  });
+  const adminApi = files.find(({ fileName }) => fileName.endsWith("/pushNotificationAdmin/pushNotificationAdmin.api.ts"))
+    ?.content;
+  const adminQueries = files.find(({ fileName }) =>
+    fileName.endsWith("/pushNotificationAdmin/pushNotificationAdmin.queries.ts"),
+  )?.content;
+  const adminConfigs = files.find(({ fileName }) =>
+    fileName.endsWith("/pushNotificationAdmin/pushNotificationAdmin.configs.ts"),
+  )?.content;
+
+  test("api file uses the owning namespace (CommonModels) for the shared parameter schema", () => {
+    expect(adminApi).toBeDefined();
+    expect(adminApi).toContain("CommonModels.TokenFiltersDto");
+    expect(adminApi).not.toContain("PushNotificationAdminModels.TokenFiltersDto");
+  });
+
+  test("queries file uses the owning namespace (CommonModels) for the shared parameter schema", () => {
+    expect(adminQueries).toBeDefined();
+    expect(adminQueries).toContain("CommonModels.TokenFiltersDto");
+    expect(adminQueries).not.toContain("PushNotificationAdminModels.TokenFiltersDto");
+  });
+
+  test("configs file uses the owning namespace (CommonModels) for the shared parameter schema", () => {
+    expect(adminConfigs).toBeDefined();
+    expect(adminConfigs).toContain("CommonModels.TokenFiltersDto");
+    expect(adminConfigs).not.toContain("PushNotificationAdminModels.TokenFiltersDto");
+  });
+});

--- a/src/generators/utils/generate/generate.acl.utils.ts
+++ b/src/generators/utils/generate/generate.acl.utils.ts
@@ -3,6 +3,7 @@ import { AclConditionsPropertyType, Endpoint } from "@/generators/types/endpoint
 import { GenerateType, GenerateTypeParams, Import } from "@/generators/types/generate";
 import { GenerateOptions } from "@/generators/types/options";
 import { getUniqueArray } from "@/generators/utils/array.utils";
+import { invalidVariableNameCharactersToCamel } from "@/generators/utils/js.utils";
 import { getNamespaceName } from "@/generators/utils/namespace.utils";
 import { capitalize, snakeToCamel } from "@/generators/utils/string.utils";
 import { getEndpointTag } from "@/generators/utils/tag.utils";
@@ -136,3 +137,28 @@ export const getAppAbilitiesType = ({ resolver, data }: Omit<GenerateTypeParams,
 
   return { appAbilitiesType, modelsImports, hasAdditionalAbilityImports };
 };
+
+/** Renders a `checkAcl(...)` call, passing the ability's conditions object only when the
+ * ability function actually expects one (i.e. the endpoint declares matching conditions). */
+export function renderAclCheckCall(
+  resolver: SchemaResolver,
+  endpoint: Endpoint,
+  replacements?: Record<string, string>,
+  indent = "",
+) {
+  const checkParams = getAbilityConditionsTypes(endpoint)?.map((condition) =>
+    invalidVariableNameCharactersToCamel(condition.name),
+  );
+  const paramNames = new Set(endpoint.parameters.map((param) => invalidVariableNameCharactersToCamel(param.name)));
+  const hasAllCheckParams = checkParams?.every((param) => paramNames.has(param));
+  const args =
+    hasAbilityConditions(endpoint) && hasAllCheckParams
+      ? `{ ${(checkParams ?? [])
+          .map((param) => {
+            const resolvedParam = replacements?.[param] ?? param;
+            return resolvedParam === param ? param : `${param}: ${resolvedParam}`;
+          })
+          .join(", ")} } `
+      : "";
+  return `${indent}checkAcl(${getImportedAbilityFunctionName(endpoint, resolver.options)}(${args}));`;
+}

--- a/src/generators/utils/generate/generate.endpoints.utils.ts
+++ b/src/generators/utils/generate/generate.endpoints.utils.ts
@@ -1,6 +1,6 @@
 import { OpenAPIV3 } from "openapi-types";
 
-import { BODY_PARAMETER_NAME, DEFAULT_HEADERS } from "@/generators/const/endpoints.const";
+import { AXIOS_REQUEST_CONFIG_NAME, BODY_PARAMETER_NAME, DEFAULT_HEADERS } from "@/generators/const/endpoints.const";
 import { SchemaResolver } from "@/generators/core/SchemaResolver.class";
 import { Endpoint } from "@/generators/types/endpoint";
 import { GenerateType } from "@/generators/types/generate";
@@ -160,6 +160,50 @@ export function getEndpointConfig(endpoint: Endpoint) {
     ...(Object.keys(headers).length ? { headers } : {}),
   };
   return endpointConfig;
+}
+
+/** Renders the body of a media-upload mutationFn: call the endpoint (without the file arg) to
+ * get upload instructions, then upload the file itself to the returned URL. Shared between
+ * renderMutation (*.queries.ts) and renderMutationContent (*.configs.ts / builderConfigs) so
+ * both mutation paths stay in sync. Lines are relative to the caller's own indent. */
+export function renderMediaUploadMutationBody({
+  resolver,
+  endpointFunction,
+  resolvedEndpointArgs,
+}: {
+  resolver: SchemaResolver;
+  endpointFunction: string;
+  resolvedEndpointArgs: string;
+}): string[] {
+  const hasAxiosRequestConfig = resolver.options.axiosRequestConfig;
+  return [
+    `const uploadInstructions = await ${endpointFunction}(${resolvedEndpointArgs}${hasAxiosRequestConfig ? `${resolvedEndpointArgs ? ", " : ""}${AXIOS_REQUEST_CONFIG_NAME}` : ""});`,
+    "",
+    "if (file && uploadInstructions.url) {",
+    `  const method = (${BODY_PARAMETER_NAME}?.method?.toLowerCase() ?? "put") as "put" | "post";`,
+    "  let dataToSend: File | FormData = file;",
+    '  if (method === "post") {',
+    "    dataToSend = new FormData();",
+    "    if (uploadInstructions.fields) {",
+    "      for (const [key, value] of uploadInstructions.fields) {",
+    "        dataToSend.append(key, value);",
+    "      }",
+    "    }",
+    '    dataToSend.append("file", file);',
+    "  }",
+    "  await axios[method](uploadInstructions.url, dataToSend, {",
+    "    headers: {",
+    '      "Content-Type": file.type,',
+    "    },",
+    "    signal: abortController?.signal,",
+    "    onUploadProgress: onUploadProgress",
+    "    ? (progressEvent) => onUploadProgress({ loaded: progressEvent.loaded, total: progressEvent.total ?? 0 })",
+    "    : undefined,",
+    "  });",
+    "}",
+    "",
+    "return uploadInstructions;",
+  ];
 }
 
 export function getUpdateQueryEndpoints(endpoint: Endpoint, endpoints: Endpoint[]) {

--- a/src/generators/utils/generate/generate.zod.utils.ts
+++ b/src/generators/utils/generate/generate.zod.utils.ts
@@ -21,12 +21,25 @@ export const getImportedZodSchemaName = (resolver: SchemaResolver, zodSchemaName
     return zodSchemaName;
   }
 
-  const tag = namespaceTag ?? resolver.getTagByZodSchemaName(zodSchemaName);
+  const tag = getOwningOrLocalProxyTag(resolver, zodSchemaName, namespaceTag);
   const namespacePrefix = resolver.options.tsNamespaces
     ? `${getNamespaceName({ type: GenerateType.Models, tag, options: resolver.options })}.`
     : "";
   return `${namespacePrefix}${zodSchemaName}`;
 };
+
+// namespaceTag only has a legitimate use when modelsInCommon forces every schema into the
+// common file: callers can still ask for the calling tag's local proxy namespace (e.g.
+// AuthModels.X, which re-exports CommonModels.X) instead of importing CommonModels directly.
+// Outside that mode, the resolver is the sole source of truth for which tag owns a schema
+// (e.g. a schema shared by 2+ tags is promoted to the common tag) - namespaceTag must not
+// override that, or shared schemas would incorrectly resolve to the endpoint's own tag.
+function getOwningOrLocalProxyTag(resolver: SchemaResolver, zodSchemaName: string, namespaceTag?: string) {
+  if (namespaceTag && resolver.options.modelsInCommon && resolver.options.splitByTags) {
+    return namespaceTag;
+  }
+  return resolver.getTagByZodSchemaName(zodSchemaName) ?? namespaceTag;
+}
 
 export const getImportedZodSchemaInferedTypeName = (
   resolver: SchemaResolver,
@@ -38,7 +51,9 @@ export const getImportedZodSchemaInferedTypeName = (
     return zodSchemaName === VOID_SCHEMA ? "void" : zodSchemaName;
   }
 
-  const tag = namespaceTag ?? resolver.getTagByZodSchemaName(zodSchemaName);
+  // See getOwningOrLocalProxyTag. namespaceTag still forces the prefix to render even when
+  // tag === currentTag.
+  const tag = getOwningOrLocalProxyTag(resolver, zodSchemaName, namespaceTag);
   const namespacePrefix =
     resolver.options.tsNamespaces && (Boolean(namespaceTag) || tag !== currentTag)
       ? `${getNamespaceName({ type: GenerateType.Models, tag, options: resolver.options })}.`


### PR DESCRIPTION
## Summary

Fix several issues in generated `builderConfigs` output and align its behavior with the existing `queries` generation path.

The changes were discovered while migrating Gaggle from standalone CLI execution to the Vite plugin integration and exposed a number of generator edge cases that were not exercised by existing consumers.

## Changes

### Builder configs generation

* Add missing `*Queries` imports in generated `*.configs.ts` files.
* Fix `useMutationEffects` typing in builder configs generation.
* Fix mutation effects execution to pass the correct arguments (`resData`, `variables`, `options`) instead of invoking `runMutationEffects()` without parameters.
* Reuse shared ACL generation logic and remove stale duplicated ACL handling.
* Ensure ACL checks only pass conditions when the ability function expects them.
* Fix `onSuccess` ordering so mutation effects cannot be unintentionally overridden by consumer options.
* Generate ACL-related imports and declarations only when ACL checks are actually used.

### Shared model resolution

* Fix schema ownership resolution for models shared across multiple tags.
* Ensure shared schemas resolve through `CommonModels` instead of incorrectly using the endpoint tag namespace.
* Preserve existing `modelsInCommon` local proxy behavior through scoped namespace resolution.

### Media upload generation

* Align media upload handling in `builderConfigs` generation with the existing queries generation path.
* Extract shared upload flow into a reusable helper.
* Ensure upload endpoints are called with DTO data only and perform the file upload through the generated presigned URL flow.
* Add missing axios imports required by generated media upload mutations.

### Cleanup

* Remove unused `OpenApiWorkspaceContext` generation scaffolding.
* Fix local build support when version metadata is not injected by CI.
* Add regression coverage for all discovered issues.

## Validation

* `tsc --noEmit` passes.
* `pnpm build` passes.
* Generator test suite passes (except for the existing unrelated fixture-based test failure).
* Verified against Gaggle:

  * Vite plugin migration works.
  * Generated code typechecks correctly.
  * Shared model resolution works.
  * Media upload generation works.
* Verified against ToS:

  * Zero generated output diff.
  * Typecheck/build pass.
  * No regressions found.
